### PR TITLE
fix #5: remove pickle file if exits before renaming tmpFile

### DIFF
--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -66,7 +66,7 @@ class _BobState():
                 pickle.dump(state, f)
                 f.flush()
                 os.fsync(f.fileno())
-            os.rename(tmpFile, self.__path)
+            os.replace(tmpFile, self.__path)
             self.__dirty = False
         else:
             self.__dirty = True


### PR DESCRIPTION
After fixing my msys / mingw installation (do not use mingw python, use msys python) the only remaining issue is the failing rename if the target file exists. 

Python-docu:
> On Windows, if dst already exists, OSError will be raised even if it is a file. 