### PR TITLE
[RFD] query-path and query-scm commands

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ..errors import BuildError
+from ..errors import BuildError, ParseError
 from ..input import RecipeSet, walkPackagePath
 from ..state import BobState
 from ..tty import colorize
@@ -288,16 +288,19 @@ esac
         return os.path.join("work", base.replace('::', os.sep), step.getLabel())
 
     @staticmethod
-    def releaseNamePersister(wrapFmt, persistent=True):
+    def releaseNamePersister(wrapFmt):
 
         def fmt(step, props):
             return BobState().getByNameDirectory(
                 wrapFmt(step, props),
                 asHexStr(step.getVariantId()),
-                step.isCheckoutStep(),
-                persistent)
+                step.isCheckoutStep())
 
         return fmt
+
+    @staticmethod
+    def releaseNameInterrogator(step, props):
+        return BobState().getExistingByNameDirectory(asHexStr(step.getVariantId()))
 
     @staticmethod
     def developNameFormatter(step, props):
@@ -338,7 +341,7 @@ esac
                     ret = os.path.join(baseDir, wrapFmt(step, props))
                 else:
                     ret = os.path.join("/bob", asHexStr(step.getVariantId()))
-            return os.path.join(ret, "workspace")
+            return os.path.join(ret, "workspace") if ret is not None else None
 
         return fmt
 
@@ -1039,9 +1042,7 @@ would get removed without acutally deleting that already.
     recipes.defineHook('releaseNameFormatter', LocalBuilder.releaseNameFormatter)
     recipes.parse()
 
-    nameFormatter = recipes.getHook('releaseNameFormatter')
-    nameFormatter = LocalBuilder.releaseNamePersister(nameFormatter, False)
-    nameFormatter = LocalBuilder.makeRunnable(nameFormatter)
+    nameFormatter = LocalBuilder.makeRunnable(LocalBuilder.releaseNameInterrogator)
 
     # collect all used paths (with and without sandboxing)
     usedPaths = set()
@@ -1068,3 +1069,121 @@ would get removed without acutally deleting that already.
         if not args.dry_run:
             removePath(d)
 
+def doQueryPath(argv, bobRoot):
+    # Local imports
+    from string import Formatter
+
+    # Configure the parser
+    parser = argparse.ArgumentParser(prog="bob query-path",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description="""Query path information.
+
+This command lists existing workspace directory names for packages given
+on the command line. Output is formatted with a format string that can
+contain placeholders
+   {name}     package name
+   {src}      checkout directory
+   {build}    build directory
+   {dist}     package directory
+The default format is '{name}<tab>{dist}'.
+
+If a directory does not exist for a step (because that step has never
+been executed or does not exist), the line is omitted.
+""")
+    parser.add_argument('packages', metavar='PACKAGE', type=str, nargs='+',
+        help="(Sub-)package to query")
+    parser.add_argument('-f', help='Output format string', default='{name}\t{dist}', metavar='FORMAT')
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
+    parser.add_argument('-c', dest="configFile", default=[], action='append',
+        help="Use config File")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--sandbox', action='store_true', help="Enable sandboxing")
+    group.add_argument('--no-sandbox', action='store_false', dest='sandbox', help="Disable sandboxing")
+    parser.set_defaults(sandbox=None)
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--develop', action='store_true',  dest='dev', help="Use developer mode", default=True)
+    group.add_argument('--release', action='store_false', dest='dev', help="Use release mode")
+
+    # Parse args
+    args = parser.parse_args(argv)
+    if args.sandbox == None:
+        args.sandbox = not args.dev
+
+    # Process defines
+    defines = {}
+    for define in args.defines:
+        d = define.split("=")
+        if len(d) == 1:
+            defines[d[0]] = ""
+        elif len(d) == 2:
+            defines[d[0]] = d[1]
+        else:
+            parser.error("Malformed define: "+define)
+
+    # Process the recipes
+    recipes = RecipeSet()
+    recipes.defineHook('releaseNameFormatter', LocalBuilder.releaseNameFormatter)
+    recipes.defineHook('developNameFormatter', LocalBuilder.developNameFormatter)
+    recipes.defineHook('developNamePersister', LocalBuilder.developNamePersister)
+    recipes.setConfigFiles(args.configFile)
+    recipes.parse()
+
+    # State variables in a class
+    class State:
+        def __init__(self):
+            self.packageText = ''
+            self.showPackage = True
+        def appendText(self, what):
+            self.packageText += what
+        def appendStep(self, step):
+            dir = step.getWorkspacePath()
+            if step.isValid() and (dir is not None) and os.path.isdir(dir):
+                self.packageText += dir
+            else:
+                self.showPackage = False
+        def print(self):
+            if (self.showPackage):
+                print(self.packageText)
+
+    if args.dev:
+        # Develop names are stable. All we need to do is to replicate build's algorithm,
+        # and when we produce a name, check whether it exists.
+        nameFormatter = recipes.getHook('developNameFormatter')
+        developPersister = recipes.getHook('developNamePersister')
+        nameFormatter = developPersister(nameFormatter)
+    else:
+        # Release names are taken from persistence.
+        nameFormatter = LocalBuilder.releaseNameInterrogator
+    nameFormatter = LocalBuilder.makeRunnable(nameFormatter)
+
+    # Find roots
+    roots = recipes.generatePackages(nameFormatter, defines, args.sandbox)
+    if args.dev:
+        touch(sorted(roots.values(), key=lambda p: p.getName()))
+
+    # Loop through packages
+    for p in args.packages:
+        # Format this package.
+        # Only show the package if all of the requested directory names are present
+        package = walkPackagePath(roots, p)
+        state = State()
+        for (text, var, spec, conversion) in Formatter().parse(args.f):
+            state.appendText(text)
+            if var is None:
+                pass
+            elif var == 'name':
+                state.appendText(p)
+            elif var == 'src':
+                state.appendStep(package.getCheckoutStep())
+            elif var == 'build':
+                state.appendStep(package.getBuildStep())
+            elif var == 'dist':
+                state.appendStep(package.getPackageStep())
+            else:
+                raise ParseError("Unknown field '{" + var + "}'")
+
+        # Show
+        state.print()

--- a/pym/bob/cmds/misc.py
+++ b/pym/bob/cmds/misc.py
@@ -59,7 +59,7 @@ def doLS(argv, bobRoot):
     recipes.parse()
 
     showAll = args.all
-    roots = recipes.generatePackages(lambda s,m: "unused", sandboxEnabled=args.sandbox).values()
+    roots = sorted(recipes.generatePackages(lambda s,m: "unused", sandboxEnabled=args.sandbox).values(), key=lambda a:a.getName())
     stack = []
     if args.package:
         steps = [ s for s in args.package.split("/") if s != "" ]

--- a/pym/bob/cmds/misc.py
+++ b/pym/bob/cmds/misc.py
@@ -167,4 +167,3 @@ def doQueryRecipe(argv, bobRoot):
 
     for fn in package.getRecipe().getSources():
         print(fn)
-

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -54,6 +54,10 @@ def __queryrecipe(*args, **kwargs):
      from .cmds.misc import doQueryRecipe
      doQueryRecipe(*args, **kwargs)
 
+def __querypath(*args, **kwargs):
+     from .cmds.build import doQueryPath
+     doQueryPath(*args, **kwargs)
+
 availableCommands = {
     "build"         : (True, __build, "Build (sub-)packages in release mode"),
     "dev"           : (True, __develop, "Build (sub-)packages in development mode"),
@@ -64,6 +68,7 @@ availableCommands = {
 
     "query-scm"     : (False, __queryscm, "Query SCM information"),
     "query-recipe"  : (False, __queryrecipe, "Query package sources"),
+    "query-path"    : (False, __querypath, "Query path information"),
 }
 
 def doHelp(extended, fd):

--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -90,17 +90,22 @@ class _BobState():
         if self.__dirty:
             self.__save()
 
-    def getByNameDirectory(self, baseDir, digest, isSourceDir, persistent):
+    def getByNameDirectory(self, baseDir, digest, isSourceDir):
         if digest in self.__byNameDirs:
             return self.__byNameDirs[digest][0]
         else:
             num = self.__byNameDirs.setdefault(baseDir, 0) + 1
             res = "{}/{}".format(baseDir, num)
-            if persistent:
-                self.__byNameDirs[baseDir] = num
-                self.__byNameDirs[digest] = (res, isSourceDir)
-                self.__save()
+            self.__byNameDirs[baseDir] = num
+            self.__byNameDirs[digest] = (res, isSourceDir)
+            self.__save()
             return res
+
+    def getExistingByNameDirectory(self, digest):
+        if digest in self.__byNameDirs:
+            return self.__byNameDirs[digest][0]
+        else:
+            return None
 
     def getAllNameDirectores(self):
         return [ d for d in self.__byNameDirs.values() if isinstance(d, tuple) ]

--- a/test/query-path/.gitignore
+++ b/test/query-path/.gitignore
@@ -1,0 +1,4 @@
+/dev
+/.bob-*
+/log.txt
+/work

--- a/test/query-path/recipes/child.yaml
+++ b/test/query-path/recipes/child.yaml
@@ -1,0 +1,6 @@
+buildVars: [MODE]
+buildScript: |
+  echo ${MODE} > result.txt
+
+packageScript: |
+  cat $1/result.txt > result.txt

--- a/test/query-path/recipes/interm1.yaml
+++ b/test/query-path/recipes/interm1.yaml
@@ -1,0 +1,10 @@
+depends:
+  - name: child
+    environment:
+      MODE: "1"
+
+buildScript: |
+  cat $2/result.txt > result.txt
+
+packageScript: |
+  cat $1/result.txt > result.txt

--- a/test/query-path/recipes/interm2.yaml
+++ b/test/query-path/recipes/interm2.yaml
@@ -1,0 +1,10 @@
+depends:
+  - name: child
+    environment:
+      MODE: "2"
+
+buildScript: |
+  cat $2/result.txt > result.txt
+
+packageScript: |
+  cat $1/result.txt > result.txt

--- a/test/query-path/recipes/root.yaml
+++ b/test/query-path/recipes/root.yaml
@@ -1,0 +1,11 @@
+root: true
+
+depends:
+  - interm1
+  - interm2
+
+buildScript: |
+  cat $2/result.txt $3/result.txt > result.txt
+
+packageScript: |
+  cat $1/result.txt > result.txt

--- a/test/query-path/run.sh
+++ b/test/query-path/run.sh
@@ -1,0 +1,79 @@
+#
+#  Blackbox tests for "query-path" command
+#
+
+# Check environment
+if test "$(type -t run_bob)" != function; then
+  echo "Please run me via run-tests.sh" >&2
+  exit 1
+fi
+
+# Clean
+rm -rf work dev .bob-*
+
+#
+#  Test path generation in release mode
+#
+
+# Must report no path for all usages because we have not built.
+test -z "$(run_bob query-path --release root)"
+test -z "$(run_bob query-path --release root/interm1/child)"
+test -z "$(run_bob query-path --release root/interm2/child)"
+
+# Perform a full release build. Must report paths for everything.
+run_bob build root
+set -- $(run_bob query-path --release root)
+test "$1" = "root"
+test "$2" = "work/root/dist/1/workspace"
+
+# It is an implementation detail which workspace is which child, so just test we get something.
+test -n "$(run_bob query-path --release root/interm1/child)"
+test -n "$(run_bob query-path --release root/interm2/child)"
+
+
+#
+#  Test path generation in dev mode
+#
+
+# Must report no path for all usages because we have not built.
+test -z "$(run_bob query-path --dev root)"
+test -z "$(run_bob query-path --dev root/interm1/child)"
+test -z "$(run_bob query-path --dev root/interm2/child)"
+
+# Build everything
+run_bob dev root
+set -- $(run_bob query-path --dev root)
+test "$1" = "root"
+test "$2" = "dev/dist/root/1/workspace"
+
+# 'query-path --dev' is the default
+PACKAGES="root root/interm1/child root/interm2/child"
+RESULT=$(run_bob query-path --dev $PACKAGES)
+test "$RESULT" = "$(run_bob query-path $PACKAGES)"
+
+# No matter in which order we build, we must get the same result.
+for i in $PACKAGES; do
+    rm -rf work dev .bob-*
+    run_bob dev $i
+    run_bob dev root
+    test "$(run_bob query-path --dev $PACKAGES)" = "$RESULT"
+done
+
+
+#
+#  Test formatting
+#
+run_bob build root
+test "$(run_bob query-path --release -f '{name}' root)" = "root"
+test "$(run_bob query-path --release -f '{name}{name}' root)" = "rootroot"
+test "$(run_bob query-path --release -f 'X{name}X' root)" = "XrootX"
+test "$(run_bob query-path --release -f '{dist}' root)" = "work/root/dist/1/workspace"
+test "$(run_bob query-path --release -f '{build}' root)" = "work/root/build/1/workspace"
+
+# We don't have source, so these report empty
+test -z "$(run_bob query-path --release -f '{src}' root)"
+test -z "$(run_bob query-path --release -f 'X{src}X' root)"
+test -z "$(run_bob query-path --release -f '{src} {build}' root)"
+test -z "$(run_bob query-path --release -f '{build} {src}' root)"
+
+echo "Test ok"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -57,6 +57,11 @@ exec_generator_test()
 	diff -Nurp $RES output
 }
 
+exec_fancy_test()
+{
+	. run.sh > log.txt
+}
+
 run_test()
 {
 	echo "Run" $1
@@ -81,6 +86,9 @@ done
 
 # run generator test
 run_test test/generator exec_generator_test
+
+# run query-path test
+run_test test/query-path exec_fancy_test
 
 # collect coverage
 if [[ $USE_COVERAGE -eq 1 ]]; then


### PR DESCRIPTION
Two new commands.

(a) `query-scm`: solves the problem that your SCM hook tells you "url xyz changed", and you want to know what to rebuild.

(b) `query-path`: allows you to find out where bob put the build result so you can postprocess that automatically (like: upload generated reports to a webserver). Disclaimer: I'm not sure I understood everything that makes up this command :-)