### PR TITLE
test: run coverage only from the current (v)env

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -4,8 +4,16 @@ cd "${0%/*}/.."
 export PYTHONPATH="${PWD}/pym"
 BOB_ROOT="$PWD"
 
+USE_COVERAGE=0
 if type -fp coverage3 >/dev/null; then
-	RUN="coverage3 run --source $PWD/pym  --parallel-mode"
+    # make sure coverage is installed in the current environment
+    if python3 -c "import coverage" 2>/dev/null; then
+	    RUN="coverage3 run --source $PWD/pym  --parallel-mode"
+        USE_COVERAGE=1
+    else
+        RUN=python3
+        echo "coverage3 is installed but not in the current environment"
+    fi
 else
 	RUN=python3
 fi
@@ -75,7 +83,7 @@ done
 run_test test/generator exec_generator_test
 
 # collect coverage
-if type -fp coverage3 >/dev/null; then
+if [[ $USE_COVERAGE -eq 1 ]]; then
 	coverage3 combine test test/blackbox/* test/generator
 fi
 


### PR DESCRIPTION
If running the tests inside a venv but coverage is only installed
outside, it was used and thus cannot import packages that are only
installed inside the venv.

This patch tests, if coverage is installed inside the current (v)env and
only uses this and not the outside one.

fix #36