### PR TITLE
add alias property

### DIFF
--- a/doc/manual/manual/configuration.rst
+++ b/doc/manual/manual/configuration.rst
@@ -1051,3 +1051,12 @@ If an override is matching the actions are then applied in the following order:
    ``replacement``. Each occurrence of ``pattern`` is replaced by
    ``replacement``.
 
+alias
+~~~~~
+
+Type: Dictionary (String -> String)
+
+Specifies alias names for packages::
+
+   alias:
+      myApp: "host/files/group/app42"

--- a/test/test_input_recipeset.py
+++ b/test/test_input_recipeset.py
@@ -104,6 +104,25 @@ class TestUserConfig(TestCase):
 
             assert recipeSet.defaultEnv() == { "FOO":"BAZ", "BAR":"BAZ" }
 
+    def testUserConfigAlias(self):
+        """Test Package Alias Names"""
+        with TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            os.mkdir("recipes")
+            with open(os.path.join("recipes","bar.yaml"), "w") as f:
+                f.write("root: true")
+            with open("default.yaml", "w") as f:
+                f.write("alias:\n")
+                f.write("    FOO: bar\n")
+            recipeSet = RecipeSet()
+            recipeSet.parse()
+            roots = recipeSet.generatePackages(lambda s,m: "unused").values()
+            names = [ "bar", "FOO" ]
+            i = 0
+            for r in roots:
+                assert r.getName() == names[i]
+                i += 1
+
     def testUserConfigMissing(self):
         """Test that missing user config fails parsing"""
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
With this you can use a alias to reduce typing effort for deep packages like a/b/c/d. This alias must be defined in default.yaml (or a file included from there) and can be used for all bob cmds.