### PR TITLE
doc: fix projectGenerator section

### DIFF
--- a/doc/manual/manual/extending.rst
+++ b/doc/manual/manual/extending.rst
@@ -210,8 +210,8 @@ A simple genertor may look like::
         return 0
 
     manifest = {
-        'apiVersion' : "0.4",
-        'generators' : {
+        'apiVersion' : "0.5",
+        'projectGenerators' : {
             'nullGenerator' : nullGenerator,
         }
     }


### PR DESCRIPTION
Some revisions of bob 0.4 didn't support project generators -> use apiVersion 0.5 for
projectGenerators. Also fixed the keyword.