### PR TITLE
project: adapt to different magic modules

### DIFF
--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -19,12 +19,12 @@ import argparse
 import sys
 import os
 import re
-import magic
 import shutil
 import stat
 import uuid
 from os.path import expanduser
 from os.path import join
+from bob.utils import summonMagic
 from collections import OrderedDict
 from pipes import quote
 
@@ -253,6 +253,7 @@ def generateEclipseProject(package, destination, updateOnly, projectName, exclud
 
         # find all executables in package dir
         runTargets = []
+        magic = summonMagic()
         if package.getPackageStep().isValid():
             packageDir = package.getPackageStep().getWorkspacePath()
             for root, directory, filenames in os.walk(packageDir):

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -19,12 +19,12 @@ import argparse
 import sys
 import re
 import os
-import magic
 import shutil
 import stat
 from os.path import expanduser
 from os.path import join
 from bob.errors import ParseError
+from bob.utils import summonMagic
 from collections import OrderedDict, namedtuple
 from pipes import quote
 
@@ -288,6 +288,7 @@ def generateQtProject(package, destination, updateOnly, projectName, args):
 
         # find all executables in package dir
         runTargets = []
+        magic = summonMagic()
         if package.getPackageStep().isValid():
             packageDir = package.getPackageStep().getWorkspacePath()
             for root, directory, filenames in os.walk(packageDir):

--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -295,3 +295,22 @@ def binLstat(path):
     return struct.pack('=QQLqLQ', float2ns(st.st_ctime), float2ns(st.st_mtime),
                        st.st_dev, st.st_ino, st.st_mode, st.st_size)
 
+
+# There are two "magic" modules with similar functionality. Find out which one we got and adapt.
+def summonMagic():
+    import magic
+    if hasattr(magic, 'from_file'):
+        # https://pypi.python.org/pypi/python-magic
+        return magic
+    elif hasattr(magic, 'open'):
+        # http://www.darwinsys.com/file/, in Debian as python3-magic
+        class WrapMagic:
+            def __init__(self):
+                self.magic = magic.open(magic.NONE)
+                self.magic.load()
+
+            def from_file(self, name):
+                return self.magic.file(name)
+        return WrapMagic()
+    else:
+        raise NotImplementedError("I do not understand your magic")


### PR DESCRIPTION
There are two "magic" modules with similar functionality. Find out which one
we got and adapt.

Discussion: http://stackoverflow.com/questions/25286176/how-to-use-python-magic-5-19-1

Debian has the "wrong one" as python3-magic, causing the blackbox tests to bomb out with

>     Run test/generator
>     An internal Exception has occured. This should not have happenend.
>     Please open an issue at https://github.com/BobBuildTool/bob with the following backtrace:
>     Traceback (most recent call last):
>       File "/home/stefan/extsrc/bob/pym/bob/scripts.py", line 103, in bob
>         availableCommands[verb][1](argv, bobRoot)
>       File "/home/stefan/extsrc/bob/pym/bob/scripts.py", line 47, in __project
>         doProject(*args, **kwargs)
>       File "/home/stefan/extsrc/bob/pym/bob/cmds/build.py", line 1008, in doProject
>         generator(package, args.args, extra)
>       File "/home/stefan/extsrc/bob/pym/bob/generators/QtCreatorGenerator.py", line 321, in qtProjectGenerator
>         generateQtProject(package, args.destination, args.update, args.name, extra)
>       File "/home/stefan/extsrc/bob/pym/bob/generators/QtCreatorGenerator.py", line 295, in generateQtProject
>         ftype = magic.from_file(os.path.join(root, filename))
>     AttributeError: 'module' object has no attribute 'from_file'

Disclaimer: I do not use project file generation and didn't test this other than running the testsuite.