### PR TITLE
eclipseGenerator: fix multiple exclude packages

### DIFF
--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -129,8 +129,11 @@ def addCConfig(cProjectFile, excludePackages, buildName, id, buildArgs, buildMeF
     cProjectFile.write('   </folderInfo>\n')
 
     cProjectFile.write('   <sourceEntries>\n')
-    for package in excludePackages:
-	    cProjectFile.write('<entry excluding="' + package + '" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>')
+    if len(excludePackages) > 0:
+        excludes = ''
+        for package in excludePackages:
+            excludes += package + '|'
+        cProjectFile.write('<entry excluding="' + excludes[:-1] + '" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>\n')
     cProjectFile.write('   </sourceEntries>\n')
 
     cProjectFile.write(' </configuration>\n')


### PR DESCRIPTION
Fixed a bug in genereated .cproject when regex matches multiple packages or
--exclude is used more than once.