### PR TITLE
Project additional includes

### DIFF
--- a/doc/manual/tutorial/compile.rst
+++ b/doc/manual/tutorial/compile.rst
@@ -260,6 +260,10 @@ QtCreator specificArgs:
     * ``--destination``: destination directory for the project files. Default is
       <workingDir>/projects/package_stack.
     * ``--name``: name of the project. Default is packageName.
+    * ``-I``: additional include directories. They will only be added for indexer and will not
+      change the buildresult.
+    * ``-f``: additional files. Normally only c[pp] and h[pp] files will be added. You can
+            add more files using a regex.
 
 EclipseCdt
 ----------
@@ -271,3 +275,5 @@ Eclipse specificArgs:
     * ``--destination``: destination directory for the project files. Default is
       <workingDir>/projects/package_stack.
     * ``--name``: name of the project. Default is packageName.
+    * ``-I``: additional include directories. They will only be added for indexer and will not
+      change the buildresult.

--- a/doc/manual/tutorial/compile.rst
+++ b/doc/manual/tutorial/compile.rst
@@ -264,6 +264,31 @@ QtCreator specificArgs:
       change the buildresult.
     * ``-f``: additional files. Normally only c[pp] and h[pp] files will be added. You can
             add more files using a regex.
+    * ``--kit``: kit to use for this project. You may want to use a different sysroot for includes
+      and buildin preprocessor settings from your compiler. To tell QtCreator which toolchain to
+      use you need to specify a kit. There are at least two options to create a kit: using the GUI
+      or the sdkTools.
+
+    The following example shows how to create a cross compiling project for the sandbox-tutorial and
+    the included arm-toolchain: ::
+
+        $ sdktool addTC \
+            --id "ProjectExplorer.ToolChain.Gcc:arm" \
+            --name "ARM-Linux-Gnueabihf" \
+            --path "<toolchain-dist>/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-g++" \
+            --abi arm-linux-generic-elf-32bit
+        $ sdktool addDebugger \
+            --id "gdb:ARM32" \
+            --name "ARM-gdb" \
+            --binary <toolchain-dist>/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/bin/arm-linux-gnueabihf-gdb
+        $ sdktool addKit \
+            --id "ARM_Linux" \
+            --name "ARM Linux Gnueabi" \
+            --devicetype Desktop \
+            --toolchain "ProjectExplorer.ToolChain.Gcc:arm" \
+            --sysroot <toolchain-dist>/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux/arm-linux-gnueabihf/libc/ \
+            --debuggerid "gdb:ARM32"
+        $ bob project qtcreator vexpress --kit ARM_LINUX
 
 EclipseCdt
 ----------

--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -265,7 +265,7 @@ def generateEclipseProject(package, destination, updateOnly, projectName, exclud
         # Generate buildme
         buildMe = []
         buildMe.append("#!/bin/sh")
-        buildMe.append("bob dev $1 " + quote(args) + " " + quote(project))
+        buildMe.append("bob dev $@ " + quote(args) + " " + quote(project))
         projectCmd = "bob project -n eclipseCdt " + quote(project) + " -u --destination " + quote(destination) + ' --name ' + quote(projectName)
         for i in additional_includes:
             projectCmd += " -I " + quote(i)

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -232,7 +232,7 @@ def generateQtProject(package, destination, updateOnly, projectName, includeDirs
         # Generate Buildme.sh
         buildMe = []
         buildMe.append("#!/bin/sh")
-        buildMe.append("bob dev $1 " + args + " " + quote(project))
+        buildMe.append("bob dev $@ " + args + " " + quote(project))
         projectCmd = "bob project -n qt-creator " + quote(project) + " -u --destination " + quote(destination) + ' --name ' + quote(projectName)
         for i in includeDirs:
             projectCmd += " -I " + quote(i)


### PR DESCRIPTION
With this you can add additional included directories (-I) to eclipse and
QtCreator projects. This may be usefull if some compiling for host where /usr/include
is unkown for bob.
For QtCreator you can now also add aditional files (e.g. *.ui) to project using a regex (-f <regex>).
