### PR TITLE
bash-completion: speedup bob project completion

### DIFF
--- a/contrib/bash-completion
+++ b/contrib/bash-completion
@@ -237,7 +237,7 @@ __bob_jenkins()
    __bob_subcommands "add export ls prune push rm set-url set-options" "jenkins"
 }
 
-__bob_project_generators()
+__bob_project()
 {
    local i c command completion_func
 
@@ -256,17 +256,12 @@ __bob_project_generators()
             __bob_complete_words "-D -E -e -n -c"
             ;;
          *)
-            __bob_complete_words "$1"
+            __bob_complete_words "$($bob project --list)"
             ;;
       esac
    else
        __bob_complete_path "--help"
    fi
-}
-
-__bob_project()
-{
-    __bob_project_generators "$($bob project --list)"
 }
 
 __bob_query_scm()


### PR DESCRIPTION
bob project --list needs to generatePackages wich takes a long time on large projects
and issn't needed for completion of packages.