### PR TITLE
input: handle git errors smoothly

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -626,7 +626,8 @@ esac
                     for (scmDir, scmDigest) in oldCheckoutState.copy().items():
                         if scmDir is None: continue
                         if scmDigest != checkoutState.get(scmDir): continue
-                        if stats[scmDir].status(checkoutStep.getWorkspacePath(), scmDir) == 'unclean':
+                        status = stats[scmDir].status(checkoutStep.getWorkspacePath(), scmDir)
+                        if (status == 'unclean') or (status == 'error'):
                             oldCheckoutState[scmDir] = None
 
                 if (self.__force or (not checkoutStep.isDeterministic()) or


### PR DESCRIPTION
In case of a aborted checkout git may be in a unclean state. For this reason some
git commands are returning a error. GitSCM.status has been modified to print the
error without raising a exception.