### PR TITLE
cvs scm: implement 'bob status'

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -1058,7 +1058,7 @@ def doStatus(argv, bobRoot):
                 stats = {}
                 for scm in checkoutStep.getScmList():
                     stats.update({ dir : scm for dir in scm.getDirectories().keys() })
-                for (scmDir, scmDigest) in oldCheckoutState.copy().items():
+                for (scmDir, scmDigest) in sorted(oldCheckoutState.copy().items(), key=lambda a:'' if a[0] is None else a[0]):
                     if scmDir is None: continue
                     if scmDigest != checkoutState.get(scmDir): continue
                     stats[scmDir].status(checkoutStep.getWorkspacePath(), scmDir, verbose)


### PR DESCRIPTION
Simple, brute-force implementation using `cvs update` as the basis. It will therefore contact the server and tell you where the server's branch differs from yours (instead of just your local modifications), but everything else probably involves manually parsing CVS's metadata files.

I'm not sure how this interacts with the `status()` call in `_cookCheckoutStep`. Documentation about the expected behaviour would have helped :-)