### PR TITLE
Added exclude option to qtcreator project file generation

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -89,7 +89,7 @@ QtCreator project generator
 
     bob project qt-project <package> [-h] [-u] [--buildCfg BUILDCFG] [--overwrite]
                            [--destination DEST] [--name NAME]
-                           [-I ADDITIONAL_INCLUDES] [-f Filter] [--kit KIT]
+                           [-I ADDITIONAL_INCLUDES] [-f Filter] [--exclude Excludes] [--kit KIT]
 
 The QtCreator project generator has the following specific options. They have
 to be passed on the command line *after* the package name.
@@ -102,6 +102,9 @@ to be passed on the command line *after* the package name.
 
 ``-f Filter, --filter Filter``
     File filter. A regex for matching additional files.
+
+``--exclude Excludes``
+    Package filter. A regex for excluding packages in QTCreator.
 
 ``-I ADDITIONAL_INCLUDES``
     Additional include directories. (added recursive starting from this directory)


### PR DESCRIPTION
Added the option to exclude projects for the qtcreator project.
This is a bit different than for eclipse:
No sym link and no include files will be created. Else qtcreator will parse all the files which we want to avoid. 

~Mark