### PR TITLE
Added some more build targets

### DIFF
--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -243,6 +243,7 @@ def eclipseCdtGenerator(package, argv, extra):
         addCConfig(cProjectFile, excludePackages, includeDirs, "Bob dev (no checkout)",id + "." + getId(), "-b", buildMeFile)
         addCConfig(cProjectFile, excludePackages, includeDirs, "Bob dev (no deps)",id + "." + getId(), "-n", buildMeFile)
         addCConfig(cProjectFile, excludePackages, includeDirs, "Bob dev (no checkout, no deps)",id + "." + getId(), "-bn", buildMeFile)
+        addCConfig(cProjectFile, excludePackages, includeDirs, "Bob dev (no checkout, clean)",id + "." + getId(), "-b --clean", buildMeFile)
 
         for name,flags in args.buildCfg:
             addCConfig(cProjectFile, excludePackages, includeDirs, name, id + "." + getId(), flags, buildMeFile)

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -110,8 +110,9 @@ def addBuildSteps(outFile, buildMeFile, buildConfigs):
     addBuildConfig(outFile, 2, "Bob dev (no checkout)", "-b", buildMeFile)
     addBuildConfig(outFile, 3, "Bob dev (no deps)", "-n", buildMeFile)
     addBuildConfig(outFile, 4, "Bob dev (no checkout, no deps)", "-nb", buildMeFile)
+    addBuildConfig(outFile, 5, "Bob dev (no checkout, clean)", "-b --clean", buildMeFile)
 
-    count = 5
+    count = 6
     for name,flags in buildConfigs:
         addBuildConfig(outFile, count, name, flags, buildMeFile)
         count += 1


### PR DESCRIPTION
Added a Debug and Clean build target. 
I think it would be easier just to choose a different build target if you need a debug buil than to create a new project file. 

How do you even develop without a proper debug build? I think this should always be an option as a build target for developing.

~Mark