### PR TITLE
Added build only (no checkout) as option for bob project

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -14,7 +14,7 @@ Synopsis
 ::
 
     bob project [-h] [--list] [-D DEFINES] [-c CONFIGFILE] [-e NAME] [-E]
-                [--resume] [-n]
+                [--resume] [-n] [-b]
                 [projectGenerator] [package] ...
 
 
@@ -44,6 +44,9 @@ Options
 ``-n``
     Do not build (bob dev) before generate project Files. RunTargets may not
     work
+
+``-b``
+    Do build only (bob dev -b) before generate project Files. No checkout
 
 ``--resume``
     Resume build where it was previously interrupted

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -1018,6 +1018,8 @@ def doProject(argv, bobRoot):
         help="Resume build where it was previously interrupted")
     parser.add_argument('-n', dest="execute_prebuild", default=True, action='store_false',
         help="Do not build (bob dev) before generate project Files. RunTargets may not work")
+    parser.add_argument('-b', dest="execute_buildonly", default=False, action='store_true',
+        help="Do build only (bob dev -b) before generate project Files. No checkout")
     args = parser.parse_args(argv)
 
     defines = {}
@@ -1085,6 +1087,7 @@ def doProject(argv, bobRoot):
     if args.execute_prebuild:
         devArgs = extra.copy()
         if args.resume: devArgs.append('--resume')
+        if args.execute_buildonly: devArgs.append('-b')
         devArgs.append(args.package)
         doDevelop(devArgs, bobRoot)
 

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -1076,7 +1076,7 @@ def doProject(argv, bobRoot):
         extra.append('-c')
         extra.append(c)
     for e in args.white_list:
-        extra.append('e')
+        extra.append('-e')
         extra.append(e)
     if args.preserve_env: extra.append('-E')
 


### PR DESCRIPTION
Added the option for a build only mode when creating projects:
bob project -b
does the same as bob dev -b (no checkout).
This should solve the issue that -n has but will allow you to generate a project if -n fails but you don't want to do a checkout.

~Mark