### PR TITLE
build: add BOB_DIRECT_DEP_PATHS

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -538,6 +538,10 @@ esac
                 [ "[{}]={}".format(quote(a.getPackage().getName()),
                                    quote(a.getExecPath()))
                     for a in step.getArguments() if a.isValid() ] ))), file=f)
+            print("declare -A BOB_DIRECT_DEP_PATHS=( {} )".format(" ".join(sorted(
+                [ "[{}]={}".format(quote(a.getPackage().getName()),
+                                   quote(a.getExecPath()))
+                    for a in step.getPackage().getDirectDepSteps() ] ))), file=f)
             print("declare -A BOB_TOOL_PATHS=( {} )".format(" ".join(sorted(
                 [ "[{}]={}".format(quote(t), quote(p))
                     for (t,p) in step.getTools().items()] ))), file=f)


### PR DESCRIPTION
Added a new array which holds all direct dependencies.

Actual you have only BOB_DEP_PATH which holds direct and indirect dependencies but you have no possibility to determine whether these are in the `depends` section of your recipe or provided by one of your dependencies. 