### PR TITLE
bob: fix getVersion

### DIFF
--- a/pym/bob/__init__.py
+++ b/pym/bob/__init__.py
@@ -31,7 +31,7 @@ def getVersion():
             pass
     elif os.path.isdir(os.path.join(root, ".git")):
         try:
-            version = subprocess.check_output("git describe --tags --dirty --always".split(" "),
+            version = subprocess.check_output("git describe --tags --dirty".split(" "),
                 cwd=root, universal_newlines=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             pass


### PR DESCRIPTION
The fallback output of git describe is not parseable by utils.compareVersion.
Removed this argument.