### PR TITLE
Qtcreator useonly

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -92,7 +92,8 @@ QtCreator project generator
 
     bob project qt-project <package> [-h] [-u] [--buildCfg BUILDCFG] [--overwrite]
                            [--destination DEST] [--name NAME]
-                           [-I ADDITIONAL_INCLUDES] [-f Filter] [--exclude Excludes] [--kit KIT]
+                           [-I ADDITIONAL_INCLUDES] [-f Filter]
+                           [--exclude Excludes] [--include Includes] [--kit KIT]
 
 The QtCreator project generator has the following specific options. They have
 to be passed on the command line *after* the package name.
@@ -108,6 +109,13 @@ to be passed on the command line *after* the package name.
 
 ``--exclude Excludes``
     Package filter. A regex for excluding packages in QTCreator.
+
+``--include Includes``
+    Include package filter. A regex for including only the specified packages in QTCreator.
+    Use single quotes to specify your regex. For exmaple: --include 'foobar-.*'
+    You can also mix the Includes with the Excludes. In this case always use the Includes option beforehand.
+    For example: --include 'foobar-.*' --exclude 'foobar-baz' This will ensure you only include packages
+    wtih foobar-* but excludes the foobar-baz package.
 
 ``-I ADDITIONAL_INCLUDES``
     Additional include directories. (added recursive starting from this directory)

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -158,6 +158,8 @@ def qtProjectGenerator(package, argv, extra):
         help="File filter. A regex for matching additional files.")
     parser.add_argument('--exclude', default=[], action='append', dest="excludes",
             help="Package filter. A regex for excluding packages in QTCreator.")
+    parser.add_argument('--include', default=[], action='append', dest="include",
+            help="Include package filter. A regex for including only the specified packages in QTCreator.")
     parser.add_argument('--kit',
         help="Kit to use for this project")
 
@@ -174,6 +176,10 @@ def qtProjectGenerator(package, argv, extra):
     if args.excludes:
         for e in args.excludes:
             excludes.append(re.compile(e))
+
+    if args.include:
+        for e in args.include:
+            excludes.append(re.compile(r"^((?!"+e+").)*$"))
 
     getCheckOutDirs(package, excludes, dirs)
     if not projectName:
@@ -314,6 +320,9 @@ def qtProjectGenerator(package, argv, extra):
         if args.excludes:
             for e in args.excludes:
                 projectCmd += " --exclude " + quote(e)
+        if args.include:
+            for e in args.include:
+                projectCmd += "--include " + quote(e)
 
         buildMe.append(projectCmd)
         generateFile(buildMe, buildMeFile)


### PR DESCRIPTION
Added the QtCreator `--use-only` feature as discussed in PR #80 .
Tested and it worked to include only projects.

~ Mark