### PR TITLE
build: do not pipe output of buildScript [RFC] [Do not merge :)]

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -473,7 +473,8 @@ esac
         errpty = pty.openpty()
         pipe   = os.pipe()
         filefds = [outpty[0], outpty[1], errpty[0], errpty[1], pipe[0], pipe[1]]
-        for p in filefds:
+
+        for p in [outpty[0], errpty[0], pipe[0]]:
             flag = fcntl.fcntl(p, fcntl.F_GETFL)
             fcntl.fcntl(p, fcntl.F_SETFL, flag | os.O_NONBLOCK)
 

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -501,12 +501,19 @@ esac
                             os.read(pipe[0], 1)
                             done = True
                         else:
-                            data = os.read(r, 1024)
+                            oldLen = 0
+                            data = bytearray(b'')
+                            # read all available data from fd
+                            blockSize = 1024
+                            while True:
+                                data = data + os.read(r, blockSize)
+                                if len(data) != oldLen + blockSize:
+                                    break
                             if ((r == erp[0]) and (self.__verbose >= 0)):
                                 sys.stderr.buffer.write(data)
                             if ((r == oup[0]) and (self.__verbose >= 1)):
                                 sys.stdout.buffer.write(data)
-                            logFile.write(ansi_escape.sub('', data.decode(sys.stdout.encoding)).replace('\r\n', '\n'))
+                            logFile.write(ansi_escape.sub('', data.decode(sys.stdout.encoding, errors='replace')).replace('\r\n', '\n'))
                 except InterruptedError:
                     # select is interrupted by SIGCHLD...
                     pass

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -93,7 +93,7 @@ if [[ -z $(git remote) ]] ; then
 fi
 # checkout only if HEAD is invalid
 if ! git rev-parse --verify -q HEAD >/dev/null ; then
-    git fetch -t origin
+    git fetch -q -t origin
     git checkout -q {REF}
 fi
 """.format(URL=self.__url, REF=self.__commit if self.__commit else "tags/"+self.__tag, DIR=self.__dir)
@@ -108,7 +108,7 @@ if [ -d {DIR}/.git ] ; then
         echo "Warning: not updating {DIR} because branch was changed manually..." >&2
     fi
 else
-    if ! git clone -b {BRANCH} {URL} {DIR} ; then
+    if ! git clone -q -b {BRANCH} {URL} {DIR} ; then
         rm -rf {DIR}/.git {DIR}/*
         exit 1
     fi

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -127,6 +127,8 @@ def bob(bobRoot):
         # explicitly close stderr to suppress further error messages
         sys.stderr.close()
     except BobError as e:
+        sys.stdout.flush()
+        sys.stderr.flush()
         print(e, file=sys.stderr)
         ret = 1
     except KeyboardInterrupt:


### PR DESCRIPTION
Many tools like gcc, ls, .. detect whether they are running on a tty or not.
If running on a tty the output is different ( colored ). To get these colors
back in bob use a pty to capure the output.

I'm using a regex to remove ansi escape codes from the output before writing the logfile. The time python need to process there regex is hopefully much less compared to the cpu time of the called script. :sunglasses: 

Also I haven't fully understood the old output processing. 
```bash
      run_script | tee -a ../log.txt
   }} 3>&1 1>&2- 2>&3- | tee -a ../log.txt
}} 3>&1 1>&2- 2>&3-
``` 
may have a different effect than my new implementation on this...  :confused: 