### PR TITLE
misc-cmds: make use of defines and config file.

### DIFF
--- a/pym/bob/cmds/misc.py
+++ b/pym/bob/cmds/misc.py
@@ -66,6 +66,10 @@ def doLS(argv, bobRoot):
                         help="Recursively display dependencies")
     parser.add_argument('-p', '--prefixed', default=False, action='store_true',
                         help="Prints the full path prefix for each package")
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
+    parser.add_argument('-c', dest="configFile", default=[], action='append',
+        help="Use config File")
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=True,
         help="Enable sandboxing")
@@ -73,11 +77,22 @@ def doLS(argv, bobRoot):
         help="Disable sandboxing")
     args = parser.parse_args(argv)
 
+    defines = {}
+    for define in args.defines:
+        d = define.split("=")
+        if len(d) == 1:
+            defines[d[0]] = ""
+        elif len(d) == 2:
+            defines[d[0]] = d[1]
+        else:
+            parser.error("Malformed define: "+define)
+
     recipes = RecipeSet()
+    recipes.setConfigFiles(args.configFile)
     recipes.parse()
 
     showAll = args.all
-    roots = recipes.generatePackages(lambda s,m: "unused", sandboxEnabled=args.sandbox)
+    roots = recipes.generatePackages(lambda s,m: "unused", defines, sandboxEnabled=args.sandbox)
     stack = []
     if args.package:
         package = walkPackagePath(roots, args.package)
@@ -119,6 +134,10 @@ are used:
 """)
     parser.add_argument('package', help="(Sub-)package to query")
 
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
+    parser.add_argument('-c', dest="configFile", default=[], action='append',
+        help="Use config File")
     parser.add_argument('-f', default=[], action='append', dest="formats",
         help="Output format for scm (syntax: scm=format). Can be specified multiple times.")
     parser.add_argument('--default', default="", help='Default for missing attributes (default: "")')
@@ -134,9 +153,20 @@ are used:
 
     args = parser.parse_args(argv)
 
+    defines = {}
+    for define in args.defines:
+        d = define.split("=")
+        if len(d) == 1:
+            defines[d[0]] = ""
+        elif len(d) == 2:
+            defines[d[0]] = d[1]
+        else:
+            parser.error("Malformed define: "+define)
+
     recipes = RecipeSet()
+    recipes.setConfigFiles(args.configFile)
     recipes.parse()
-    rootPackages = recipes.generatePackages(lambda s,m: "unused")
+    rootPackages = recipes.generatePackages(lambda s,m: "unused", defines)
     package = walkPackagePath(rootPackages, args.package)
 
     # update formats
@@ -168,12 +198,27 @@ def doQueryRecipe(argv, bobRoot):
     parser = argparse.ArgumentParser(prog="bob query-recipe",
         description="Query recipe and class files of package.")
     parser.add_argument('package', help="(Sub-)package to query")
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
+    parser.add_argument('-c', dest="configFile", default=[], action='append',
+        help="Use config File")
 
     args = parser.parse_args(argv)
 
+    defines = {}
+    for define in args.defines:
+        d = define.split("=")
+        if len(d) == 1:
+            defines[d[0]] = ""
+        elif len(d) == 2:
+            defines[d[0]] = d[1]
+        else:
+            parser.error("Malformed define: "+define)
+
     recipes = RecipeSet()
+    recipes.setConfigFiles(args.configFile)
     recipes.parse()
-    rootPackages = recipes.generatePackages(lambda s,m: "unused")
+    rootPackages = recipes.generatePackages(lambda s,m: "unused", defines)
     package = walkPackagePath(rootPackages, args.package)
 
     for fn in package.getRecipe().getSources():

--- a/test/commands/.gitignore
+++ b/test/commands/.gitignore
@@ -1,0 +1,3 @@
+work/
+dev/
+log.txt

--- a/test/commands/recipes/root.yaml
+++ b/test/commands/recipes/root.yaml
@@ -1,0 +1,12 @@
+root: True
+
+buildVars: [FOO, BAR]
+buildScript: |
+    if [[ $FOO != 1 ]]; then
+        exit 1
+    fi
+    if [[ $BAR != 1 ]]; then
+        exit 1
+    fi
+
+packageScript: "true"

--- a/test/commands/run.sh
+++ b/test/commands/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Test that all commands working on packages accect arguments which can influence the
+# package stack. These are -D and -c at the moment.
+
+cmds=$(python3 -c "import sys,os
+sys.path.append(os.path.join(os.getcwd(), '..', '..', 'pym'))
+from bob.scripts import availableCommands
+for cmd, (hl, func, help) in sorted(availableCommands.items()):
+    print(cmd)")
+
+for c in $cmds; do
+    if ( [ $c == "clean" ] || [ $c == "jenkins" ] || [ $c == "help" ] || [ $c == "project" ] ); then
+        continue
+    fi
+    run_bob $c -DBAR=1 -c testconfig root
+done
+run_bob project qt-creator -DBAR=1 -c testconfig --kit=none root 

--- a/test/commands/testconfig.yaml
+++ b/test/commands/testconfig.yaml
@@ -1,0 +1,3 @@
+environment:
+    FOO: "1"
+


### PR DESCRIPTION
Make ls, query-recipe and query-scm able to use -D and -c arguments. Also added a small unit test testing all highlevel commands if they are aware of -D and -c argument. 
