### PR TITLE
a different approach to fake a tty... [Do not merge :) ]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 .coverage
 __pycache__/
+isatty.so

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,13 @@ SPHINX := $(shell command -v sphinx-build 2>/dev/null)
 
 .PHONY: all install pym check doc
 
-all: bin/namespace-sandbox pym check doc
+all: bin/namespace-sandbox pym check doc isatty
 
 bin/namespace-sandbox: $(patsubst %,$(DIR)/%,$(SOURCE) $(HEADERS))
 	@gcc -o $@ -std=c99 $^ -lm
+
+isatty:
+	@echo "int isatty(int fd) { return 1; }" | gcc -O2 -fpic -shared -ldl -o bin/isatty.so -xc -
 
 pym:
 	@python3 -m compileall pym
@@ -36,6 +39,7 @@ pym:
 install: all
 	@mkdir -p $(DESTDIR)/bin $(DESTDIR)/lib/bob/bin
 	@cp bin/namespace-sandbox $(DESTDIR)/lib/bob/bin
+	@cp bin/isatty.so $(DESTDIR)/lib/bob/bin
 	@cp bin/namespace-sandbox $(DESTDIR)/bin/bob-namespace-sandbox
 	@cp -r bob bob-hash-engine bob-hash-tree contrib pym $(DESTDIR)/lib/bob
 	@ln -sf ../lib/bob/bob $(DESTDIR)/bin


### PR DESCRIPTION
Testing #86 a few issues came up. E.g. is there is output on stdout and stderr it will get out of order. 
```python
root: True

buildScript: |
    echo "This goes to stdout"
    echo "This goes to stderr" 1>&2
    echo -e "Some binary data \xca\xfe mixed with normal text"

packageScript: "true"
```

gives:
```
### START: Tue Dec  6 20:13:54 CET 2016
This goes to stdout
Some binary data �� mixed with normal text
This goes to stderr
### END(0): Tue Dec  6 20:13:54 CET 2016
```
in the log.txt and
```
>> root
   BUILD     dev/build/root/1/workspace
### START: Tue Dec  6 20:13:54 CET 2016
This goes to stdout
Some binary data �� mixed with normal text
### END(0): Tue Dec  6 20:13:54 CET 2016
This goes to stderr
   PACKAGE   dev/dist/root/1/workspace
```
on stdout / stderr.

Using a preload lib doesn't have this disadvantages ... but maybe some others... :wink: 
What do you think?