### PR TITLE
Fixes versioning via Git.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ install: all
 		ln -s $(DESTDIR)/lib/bob/contrib/bash-completion $(DESTDIR)/share/bash-completion/bob ; \
 	fi
 	@if [ -d .git ] ; then \
-		git describe --tags --dirty --always > $(DESTDIR)/lib/bob/version ; \
+		git describe --tags --dirty > $(DESTDIR)/lib/bob/version 2> /dev/null \
+		|| rm -rf $(DESTDIR)/lib/bob/version ; \
 	else \
 		rm -rf $(DESTDIR)/lib/bob/version ; \
 	fi


### PR DESCRIPTION
The new version will no longer write something like `[SHORT_COMMIT_HASH]-dirty` into the version file. That caused bob's version check to fail.