### PR TITLE
Qt/EclipseGenerator: fix crash on broken symlink

### DIFF
--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -310,9 +310,11 @@ def eclipseCdtGenerator(package, argv, extra):
             packageDir = package.getPackageStep().getWorkspacePath()
             for root, directory, filenames in os.walk(packageDir):
                 for filename in filenames:
-                    ftype = magic.from_file(os.path.join(root, filename))
-                    if 'executable' in ftype and 'x86' in ftype:
-                        createLaunchFile(open(os.path.join(destination, filename + ".launch"), 'w'),
+                    try:
+                        ftype = magic.from_file(os.path.join(root, filename))
+                        if 'executable' in ftype and 'x86' in ftype:
+                            createLaunchFile(open(os.path.join(destination, filename + ".launch"), 'w'),
                                 os.path.join(os.getcwd(), root, filename), projectName)
-
+                    except OSError:
+                        pass
 

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -404,9 +404,12 @@ def qtProjectGenerator(package, argv, extra):
             packageDir = package.getPackageStep().getWorkspacePath()
             for root, directory, filenames in os.walk(packageDir):
                 for filename in filenames:
-                    ftype = magic.from_file(os.path.join(root, filename))
-                    if 'executable' in ftype and 'x86' in ftype:
-                        runTargets.append(RunStep(os.path.join(os.getcwd(), root), filename))
+                    try:
+                        ftype = magic.from_file(os.path.join(root, filename))
+                        if 'executable' in ftype and 'x86' in ftype:
+                            runTargets.append(RunStep(os.path.join(os.getcwd(), root), filename))
+                    except OSError:
+                        pass
 
         with open(sharedFile, 'w') as sharedFile:
             sharedFile.write(template_head)


### PR DESCRIPTION
Accept a OSError while searching for executables. e.g. 'FileNotFoundException'
in case of a broken symlink.