### PR TITLE
Fix handling of interrupted/failed steps

### DIFF
--- a/test/rerun-failed-build/recipes/foo.c
+++ b/test/rerun-failed-build/recipes/foo.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+	printf("Hello world!\n");
+	return 0;
+}

--- a/test/rerun-failed-build/recipes/root.yaml
+++ b/test/rerun-failed-build/recipes/root.yaml
@@ -1,0 +1,12 @@
+root: True
+
+checkoutScript: |
+    [ -e foo.c ] || cp $<<foo.c>> foo.c
+
+buildScript: |
+    rm -rf *
+    gcc -o foo $1/foo.c
+
+packageVars: [FOO]
+packageScript: |
+    cp -a $1/foo .

--- a/test/rerun-failed-build/run.sh
+++ b/test/rerun-failed-build/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# If a step is run Bob must not rely on the old state of the workspace anymore.
+# Failing steps must thus always be run again.
+
+# build normally
+run_bob dev root
+
+# introduce some error in the sources -> expected fail
+echo "#error fail" > dev/src/root/1/workspace/foo.c
+if run_bob dev root 2>/dev/null ; then
+	echo "Expected fail"
+	exit 1
+fi
+
+# run again and force package step
+rm dev/src/root/1/workspace/foo.c
+run_bob dev root -DFOO=bar


### PR DESCRIPTION
Bob did not internally prepare for the failed execution of a step. Instead the previously determined input and result of the step was kept and no information was left that the work space is in an undefined state.

This PR fixes the problem and adds a test case that previously failed exactly due to the reason above.

Fixes #102 