### PR TITLE
Redefine build-id

### DIFF
--- a/doc/manual/concepts.rst
+++ b/doc/manual/concepts.rst
@@ -84,12 +84,15 @@ where
 * *env* is the sorted list of the environment key-value-pairs and
 * *input* is the list of all results that are passed to the step (i.e. previous step, dependencies).
 
+To keep the Variant-Id stable in the long run the scripts of SCMs in the
+checkout step are replaced by a symbolic representation.
+
 There exists also a second implicit version, called Build-Id, which identifies
 the build result in advance. The Build-Id can be used to grab matching build
 artifacts from another build server instead of building them locally. The
-Build-Id is derived from the source specification of the checkout step
-(commit-Ids, SVN URL+revision, ...), the build/package Scripts, the environment
-and all Build-Ids of the recipe dependencies:
+Build-Id is derived from the actual sources created by the checkout step, the
+build/package Scripts, the environment and all Build-Ids of the recipe
+dependencies:
 
 .. math::
 
@@ -107,14 +110,9 @@ where
 * *input* is the list of all results that are passed to the step (i.e. previous step, dependencies).
 
 The special property of the Build-Id is that it represents the expected result.
-Actually there are two Build-Ids: a static and a dynamic one. The static
-Build-Id of a step is only defined if the step and any of its dependencies is
-deterministic. For indeterministic checkouts the dynamic Build-Id is defined
-as the hash of the result of the checkout step. Compared to the Package- and
-static Build-Id the dynamic Build-Id is not computable in advance but requires
-to execute certain checkout steps. To keep the Build-Id stable in the long run
-the scripts of SCMs in the checkout step are replaced by a symbolic
-representation.
+To calculate it, all involved checkout steps have to be executed and the result
+of the checkouts have to get hashed.
+
 
 Variant management
 ------------------

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -77,11 +77,7 @@ class SpecHasher:
         if isinstance(data, bytes):
             self.lines.extend(iter(genHexSlice(asHexStr(data))))
         else:
-            bid = data.getBuildId()
-            if bid is None:
-                self.lines.append("<" + JenkinsJob._buildIdName(data))
-            else:
-                self.lines.append("=" + asHexStr(bid))
+            self.lines.append("<" + JenkinsJob._buildIdName(data))
 
     def digest(self):
         return "\n".join(self.lines + ["}"])
@@ -90,11 +86,7 @@ class SpecHasher:
 def getBuildIdSpec(step):
     """Return bob-hash-engine spec to calculate build-id of step"""
     if step.isCheckoutStep():
-        bid = step.getBuildId()
-        if bid is None:
-            return "#" + step.getWorkspacePath()
-        else:
-            return "=" + asHexStr(bid)
+        return "#" + step.getWorkspacePath()
     else:
         return step.getDigest(lambda s: s, True, SpecHasher)
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -989,19 +989,6 @@ class Step(metaclass=ABCMeta):
 
         return h.digest()
 
-    def getBuildId(self):
-        """Return static Build-Id of this Step.
-
-        The Build-Id represents the expected result of the Step. This method
-        will return None if the Build-Id cannot be determined in advance.
-        """
-        try:
-            ret = self.__buildId
-        except AttributeError:
-            ret = self.__buildId = self.getDigest(lambda step: step.getBuildId(), True) \
-                                    if self.isDeterministic() else None
-        return ret
-
     def getSandbox(self):
         """Return Sandbox used in this Step.
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2065,7 +2065,7 @@ class Recipe(object):
         for s in states.values(): s.onFinish(env, tools, self.__properties, p)
 
         if self.__shared:
-            if packageStep.getBuildId() is None:
+            if not packageStep.isDeterministic():
                 raise ParseError("Shared packages must be deterministic!")
 
         # remember calculated package

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -866,17 +866,19 @@ class Step(metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def isDeterministic(self):
         """Return whether the step is deterministic.
 
         Checkout steps that have a script are considered indeterministic unless
         the recipe declares it otherwise (checkoutDeterministic). Then the SCMs
-        are checked if they all consider themselves deterministic.
+        are checked if they all consider themselves deterministic. Build and
+        package steps are always deterministic.
 
-        Build and package steps are always deterministic.
+        The determinism is defined recursively for all arguments, tools and the
+        sandbox of the step too. That is, the step is only deterministic if all
+        its dependencies and this step itself is deterministic.
         """
-        pass
+        return all(arg.isDeterministic() for arg in self.getAllDepSteps())
 
     def isValid(self):
         """Returns True if this step is valid, False otherwise."""
@@ -1244,7 +1246,9 @@ class CheckoutStep(Step):
         return dirs
 
     def isDeterministic(self):
-        return self._coreStep.deterministic and all([ s.isDeterministic() for s in self._coreStep.scmList ])
+        return ( self._coreStep.deterministic and
+                 all([ s.isDeterministic() for s in self._coreStep.scmList ]) and
+                 super().isDeterministic() )
 
 class RegularStep(Step):
     def construct(self, package, pathFormatter, sandbox, label, script=(None, None),
@@ -1262,10 +1266,6 @@ class RegularStep(Step):
 
     def getDigestScript(self):
         return self._coreStep.digestScript
-
-    def isDeterministic(self):
-        """Regular steps are assumed to be deterministic."""
-        return True
 
 class CoreBuildStep(CoreStep):
     __slots__ = [ "script", "digestScript" ]


### PR DESCRIPTION
Do not treat tags/commits any different from branches when computing the build-id.

Fixes #106 