### PR TITLE
scm: fix crash while hashing scmOverrides

### DIFF
--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -45,11 +45,11 @@ class ScmOverride:
 
     def __hash__(self):
         return hash((frozenset(self.__match.items()), frozenset(self.__del),
-            frozenset(self.__set.items()), frozenset(self.__replaceRaw.items())))
+            frozenset(self.__set.items()), frozenset(self.__replace.items())))
 
     def __eq__(self, other):
-        return ((self.__match, self.__del, self.__set, self.__replaceRaw) ==
-            (other.__match, other.__del, other.__set, other.__replaceRaw))
+        return ((self.__match, self.__del, self.__set, self.__replace) ==
+            (other.__match, other.__del, other.__set, other.__replace))
 
     def mangle(self, scm):
         ret = False

--- a/test/status/default.yaml
+++ b/test/status/default.yaml
@@ -3,7 +3,11 @@ scmOverrides:
       match:
           scm: "git"
       set:
-          dir: "git"
+          dir: "not_working_but_replaced_below"
+      replace:
+          dir:
+            pattern: ".*"
+            replacement: "git"
     -
       match:
           scm: "url"


### PR DESCRIPTION
Fixes a regression brought in with 914f5f and added replace keyword to unittest.

(fixes #119)