### PR TITLE
Meta vars

### DIFF
--- a/contrib/bash-completion
+++ b/contrib/bash-completion
@@ -32,7 +32,7 @@ __bob_complete_words()
    done
 }
 
-__bob_commands="build dev clean help jenkins ls project status  query-scm query-recipe query-path"
+__bob_commands="build dev clean help jenkins ls project status  query-scm query-recipe query-path query-meta"
 
 __bob_complete_path()
 {
@@ -268,6 +268,15 @@ __bob_query_path()
       COMPREPLY=( $(compgen -a -f -o dirnames "$cur" | cut -f 1 -d '.' ) )
    else
       __bob_complete_path "-f -D -c --sandbox --no-sandbox --develop --release"
+   fi
+}
+
+__bob_query_meta()
+{
+   if [[ "$prev" = "-c" ]] ; then
+      COMPREPLY=( $(compgen -a -f -o dirnames "$cur" | cut -f 1 -d '.' ) )
+   else
+      __bob_complete_path "-r -D -c"
    fi
 }
 

--- a/doc/manpages/bob-query-meta.rst
+++ b/doc/manpages/bob-query-meta.rst
@@ -1,0 +1,36 @@
+
+.. _manpage-query-meta:
+
+bob-query-meta
+==============
+
+.. only:: not man
+
+   Name
+   ----
+
+   bob-query-meta - Query metaEnvironment variables
+
+Synopsis
+--------
+
+::
+
+    bob query-meta [-h] [-D DEFINES] [-c CONFIGFILE] [-r] PACKAGE [PACKAGE ...]
+
+Description
+-----------
+
+This command lists variables from the metaEnvironment section of the recipe.
+
+Options
+-------
+
+``-c CONFIGFILE``
+    Use config File
+
+``-D DEFINES``
+    Override default environment variable
+
+``-r``
+    Also list metaEnvironment variables for all dependencies.

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -746,6 +746,18 @@ of the respective attributes of the recipe. For example the scripts of the
 inherited class of all steps are inserted in front of the scripts of the
 current recipe. 
 
+metaEnvironment
+~~~~~~~~~~~~~~~
+
+Type: Dictionary (String -> String)
+
+metaEnvironment variables behave like :ref:`configuration-recipes-privateenv` variables.
+They overrule other environment variables and can be used in all steps, but substitution is not
+available. In addition all metaEnvironment variables are added to the audit no matter they are
+used in a step or not.
+This predestines metaEnvironment variables to add the license type or version of a package.
+
+The :ref:`manpage-query-meta` command can be used to retrieve metaEnvironment variables.
 
 multiPackage
 ~~~~~~~~~~~~

--- a/pym/bob/audit.py
+++ b/pym/bob/audit.py
@@ -84,7 +84,7 @@ class Artifact:
             'date'     : str
         },
         "env" : str,
-        "metaEnv" : { schema.Optional(str) : str },
+        schema.Optional('metaEnv') : str,
         "scms" : [ dict ],
         schema.Optional("recipes") : dict,
         "dependencies" : {
@@ -148,7 +148,7 @@ class Artifact:
         self.__defines = data["meta"]
         self.__build = data["build"]
         self.__env = data["env"]
-        self.__metaEnv = data["metaEnv"]
+        self.__metaEnv = data.get("metaEnv", {})
 
         self.__scms = []
         scms = data["scms"]
@@ -186,10 +186,12 @@ class Artifact:
             "meta" : self.__defines,
             "build" : self.__build,
             "env" : self.__env,
-            "metaEnv" : self.__metaEnv,
             "scms" : [ s.dump() for s in self.__scms ],
             "dependencies" : dependencies
         }
+
+        if self.__metaEnv:
+            ret[ "metaEnv"] = self.__metaEnv
 
         if self.__recipes is not None:
             ret["recipes"] = self.__recipes.dump()

--- a/pym/bob/audit.py
+++ b/pym/bob/audit.py
@@ -84,6 +84,7 @@ class Artifact:
             'date'     : str
         },
         "env" : str,
+        "metaEnv" : { schema.Optional(str) : str },
         "scms" : [ dict ],
         schema.Optional("recipes") : dict,
         "dependencies" : {
@@ -125,6 +126,7 @@ class Artifact:
             'date'     : str(datetime.utcnow()),
         }
         self.__env = ""
+        self.__metaEnv = {}
         self.__scms = []
         self.__deps = []
         self.__tools = {}
@@ -146,6 +148,7 @@ class Artifact:
         self.__defines = data["meta"]
         self.__build = data["build"]
         self.__env = data["env"]
+        self.__metaEnv = data["metaEnv"]
 
         self.__scms = []
         scms = data["scms"]
@@ -183,6 +186,7 @@ class Artifact:
             "meta" : self.__defines,
             "build" : self.__build,
             "env" : self.__env,
+            "metaEnv" : self.__metaEnv,
             "scms" : [ s.dump() for s in self.__scms ],
             "dependencies" : dependencies
         }
@@ -217,6 +221,9 @@ class Artifact:
     def addTool(self, name, tool):
         self.__tools[name] = tool
         self.__id = None
+
+    def addMetaEnv(self, var, value):
+        self.__metaEnv[var] = value
 
     def setSandbox(self, sandbox):
         self.__sandbox = sandbox
@@ -329,6 +336,9 @@ class Audit:
         audit = Audit.fromFile(tool)
         self.__merge(audit)
         self.__artifact.addTool(name, audit.getId())
+
+    def addMetaEnv(self, var, value):
+        self.__artifact.addMetaEnv(var, value)
 
     def setSandbox(self, sandbox):
         audit = Audit.fromFile(sandbox)

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -335,6 +335,8 @@ esac
         audit.addDefine("recipe", step.getPackage().getRecipe().getName())
         audit.addDefine("package", "/".join(step.getPackage().getStack()))
         audit.addDefine("step", step.getLabel())
+        for var, val in step.getPackage().getMetaEnv().items():
+            audit.addMetaEnv(var, val)
         audit.setRecipesAudit(step.getPackage().getRecipe().getRecipeSet().getScmAudit())
         audit.setEnv(os.path.join(step.getWorkspacePath(), "..", "env"))
         if step.isCheckoutStep():

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -375,6 +375,8 @@ class JenkinsJob:
             "-D", "jenkins-node", '"$NODE_NAME"',
             "-D", "jenkins-build-url", '"$BUILD_URL"'
         ]
+        for (var, val) in step.getPackage().getMetaEnv().items():
+            cmd.extend(["-E", var, quote(val)])
         recipesAudit = step.getPackage().getRecipe().getRecipeSet().getScmAudit()
         if recipesAudit is not None:
             cmd.extend(["--recipes", quote(json.dumps(recipesAudit.dump()))])

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -214,6 +214,7 @@ def auditEngine():
     parser.add_argument("-D", dest="defines", action="append", default=[], nargs=2)
     parser.add_argument("--arg", action="append", default=[])
     parser.add_argument("--env")
+    parser.add_argument("-E", action="append", default=[], nargs=2)
     parser.add_argument("--recipes")
     parser.add_argument("--sandbox")
     parser.add_argument("--scm", action="append", default=[], nargs=3)
@@ -233,6 +234,7 @@ def auditEngine():
         except ValueError:
             raise BuildError("Invalid digest argument")
         if args.env is not None: gen.setEnv(args.env)
+        for (name, value) in args.metaEnv: gen.addMetaEnv(name, value)
         for (name, value) in args.defines: gen.addDefine(name, value)
         for (name, workspace, dir) in args.scm: gen.addScm(name, workspace, dir)
         for (name, audit) in args.tool: gen.addTool(name, audit)

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -59,6 +59,10 @@ def __queryscm(*args, **kwargs):
      from .cmds.misc import doQuerySCM
      doQuerySCM(*args, **kwargs)
 
+def __querymeta(*args, **kwargs):
+     from .cmds.misc import doQueryMeta
+     doQueryMeta(*args, **kwargs)
+
 def __queryrecipe(*args, **kwargs):
      from .cmds.misc import doQueryRecipe
      doQueryRecipe(*args, **kwargs)
@@ -80,6 +84,7 @@ availableCommands = {
     "query-scm"     : (False, __queryscm, "Query SCM information"),
     "query-recipe"  : (False, __queryrecipe, "Query package sources"),
     "query-path"    : (False, __querypath, "Query path information"),
+    "query-meta"    : (False, __querymeta, "Query Package meta information"),
 }
 
 def doHelp(extended, fd):


### PR DESCRIPTION
This adds meta variables to recipes. They should be used to hold a common set of informations like versions, license, author. Maybe also a short description can be added as a meta var to 'search' for packages using `bob query-meta -f DESCRIPTION | grep "whatever"` ...

Not sure if it's necessary to add a new keyword - `privateEnvironment` variables basically provide the same functionality. But I think it makes sense to distinguish between a `privateEnvironment` and a `metaVar`.

Next steps:
I think bob should be aware of some variables (VERSION, LICENSE, LICENSE_FILE) and add them to the audit trail. This will make it possible to generate a list of used licenses in a project like the manifest file generated by bitbake.

Feedback welcome.