### PR TITLE
Use srcdir for configure call

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -324,7 +324,7 @@ newline preserving block literal. See the following example (note the pipe
 symbol on the end of the first line)::
 
     buildScript: |
-        ./configure
+        $1/configure
         make
 
 The script is subject to file inclusion with the ``$<<path>>`` and


### PR DESCRIPTION
When the build script is called a configure script is not available in the current directory it's only in the source dir.