### PR TITLE
faster Jenkins job calculation by shorten description

### DIFF
--- a/doc/manpages/bob-jenkins.rst
+++ b/doc/manpages/bob-jenkins.rst
@@ -24,6 +24,7 @@ Available sub-commands:
     bob jenkins add [-h] [-n NODES] [-o OPTIONS] [-w] [-p PREFIX] [-r ROOT]
                     [-D DEFINES] [--keep] [--download] [--upload]
                     [--no-sandbox] [--credentials CREDENTIALS] [--clean]
+                    [--shortdescription] [--longdescription]
                     name url
     bob jenkins export [-h] name dir
     bob jenkins graph [-h] name
@@ -37,6 +38,7 @@ Available sub-commands:
                             [--keep | --no-keep] [--download | --no-download]
                             [--upload | --no-upload] [--sandbox | --no-sandbox]
                             [--clean | --incremental] [--autotoken AUTHTOKEN]
+                            [--shortdescription]
                             name
     bob jenkins set-url [-h] name url
 
@@ -80,6 +82,9 @@ Options
 ``--keep``
     Keep obsolete jobs by disabling them
 
+``--longdescription``
+    Every path to a package will be calculated and displayed in job description
+
 ``-n NODES, --nodes NODES``
     Label for Jenkins Slave
 
@@ -122,6 +127,10 @@ Options
 
 ``--sandbox``
     Enable sandboxing
+
+``--shortdescription``
+    Do not calculate every path for every variant.
+    Leads to short job description: One path for each variant.
 
 ``-U UNDEFINES``
     Undefine environment variable override

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -35,7 +35,6 @@ import re
 import ssl
 import sys
 import textwrap
-import time
 import urllib.parse
 import xml.etree.ElementTree
 


### PR DESCRIPTION
As discussed in a meeting last week I implemented a parameter to make "jenkins push" and "jenkins export" faster. By inserting a return condition for already visited packages, calculating Jobs just takes some seconds.