### PR TITLE
jenkins: use binary artifact server for sharing

### DIFF
--- a/contrib/bash-completion
+++ b/contrib/bash-completion
@@ -111,7 +111,7 @@ __bob_jenkins_add()
 
    case "$cur" in
       -*)
-         __bob_complete_words "--credentials -D -h --help -n --nodes --no-sandbox -p --prefix -r --root --upload -w --windows"
+         __bob_complete_words "--credentials -D -h --help -n --nodes --no-sandbox -p --prefix -r --root --upload --download -w --windows"
          ;;
       *)
          if [[ "$prev" = "-r" ]] ; then
@@ -213,7 +213,7 @@ __bob_jenkins_set_options()
 
    case "$cur" in
       -*)
-         __bob_complete_words "-h --help -n --nodes -p --prefix --add-root --del-root -D -U --credentials --upload --no-upload --sandbox --no-sandbox"
+         __bob_complete_words "-h --help -n --nodes -p --prefix --add-root --del-root -D -U --credentials --upload --no-upload --sandbox --no-sandbox --download --no-download"
          ;;
       *)
          if [[ "$prev" = "--add-root" ]] ; then

--- a/doc/manpages/bob-jenkins.rst
+++ b/doc/manpages/bob-jenkins.rst
@@ -165,6 +165,19 @@ Extended Options
 The following Jenkins plugin options are available. Any unrecognized options
 are ignored.
 
+artifacts.copy
+    This options selects the way of sharing archives between workspaces.
+    Possible values are:
+      * jenkins:
+         Use copy artifacts pluing to copy result and buildId to jenkins-master.
+         The downstream job will afterwards be configured to use copy artifact
+         plugin again and copy the artifact into it's workspace. This is the
+         default.
+      * archive:
+         Only copy the buildID file to to jenkins master and use the binary
+         archive for sharing artifacts. Must be used together with ``--upload``
+         and ``--download``.
+
 scm.git.shallow
     Instruct the Jenkins git plugin to create shallow clones with a history
     truncated to the specified number of commits. If the parameter is unset
@@ -189,4 +202,5 @@ shared.dir
     directory set this option to an absolute path. If you expand Jenkins
     environment variables make sure that they follow the syntax of the default
     value because the path is also expanded by the Token Macro plugin.
+
 


### PR DESCRIPTION
Added a option to make use of the binary artifacts server for sharing
artifacts between jobs. This may lower the load on jenkins master.