### PR TITLE
Allow `bob help` as an alternative to `bob --help`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.pyc
+.*.swp
 .coverage
 __pycache__/
 /htmlcov

--- a/pym/bob/cmds/help.py
+++ b/pym/bob/cmds/help.py
@@ -22,6 +22,8 @@ import sys
 def doHelp(availableCommands, argv, bobRoot):
     parser = argparse.ArgumentParser(prog="bob help",
         description="Display help information about command.")
+    # Help without a command parameter gets handled by the main argument parser
+    # in pym/bob/scripts.py.
     parser.add_argument('command', help="Command to get help for")
 
     args = parser.parse_args(argv)

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -162,6 +162,13 @@ def bob(bobRoot):
             print("No command specified. Use 'bob -h' for help.", file=sys.stderr)
             return 2
 
+        # Shortcut for 'bob help' displaying the same help screen like 'bob
+        # --help' would do. The 'bob help COMMAND' case is handled by help from
+        # the available commands.
+        if args.command == "help" and len(args.args) == 0:
+            parser.print_help()
+            return 0
+
         if args.command in availableCommands:
             if args.directory is not None:
                 for i in args.directory:


### PR DESCRIPTION
I attempted several times to use `bob help` as I'm used from Git & Co. So why not accepting this command verb without any further options as the other cool cats around do?

Yes, this predates the responsibility of the help command implemented in help.py. As this one only handles the help verb with an additional command there should be no trap for young players. A unified/hierarchical argument parser might streamline this.