### PR TITLE
Makes the man page installation more general.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,10 @@ install: all
 		rm -rf $(DESTDIR)/lib/bob/version ; \
 	fi
 ifdef SPHINX
-	@mkdir -p $(DESTDIR)/share/man/man1
-	@cp doc/_build/man/*.1 $(DESTDIR)/share/man/man1/
+	@for num in 1 7 ; do \
+		mkdir -p $(DESTDIR)/share/man/man$$num ; \
+		cp doc/_build/man/*.$$num $(DESTDIR)/share/man/man$$num/ ; \
+	done
 endif
 
 check:


### PR DESCRIPTION
In order to be able to install different types (numbers) of man pages
this includes a new for loop iterating over all currently present man
page types (numbers). This is extensible more easily than having to
`mkdir` and `cp` for each and every new number.