### PR TITLE
Add git remotes

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -536,6 +536,7 @@ git `Git`_ project               | ``url``: URL of remote repository
                                  | ``tag``: Checkout this tag (optional, overrides branch attribute)
                                  | ``commit``: SHA1 commit Id to check out (optional, overrides branch or tag attribute)
                                  | ``rev``: Canonical git-rev-parse revision specification (optional, see below)
+                                 | ``remote-*``: additional remote repositories (optional, see below)
 svn `Svn`_ repository            | ``url``: URL of SVN module
                                  | ``revision``: Optional revision number (optional)
 cvs CVS repository               | ``cvsroot``: repository location ("``:ext:...``", path name, etc.)
@@ -573,6 +574,12 @@ described in git-rev-parse(1) the following formats are currently supported:
   The symbolic name of a tag.
 * refs/heads/<branchname>, e.g. refs/heads/master.
   The name of a branch.
+
+The ``remote-*`` property allows adding extra remotes whereas the part after
+``remote-`` corresponds to the remote name and the value given corresponds to
+the remote URL. For example ``remote-my_name`` set to ``some/url.git`` will
+result in an additional remote named ``my_name`` and the URL set to
+``some/url.git``.
 
 The Svn SCM, like git, requires the ``url`` attribute too. If you specify a
 numeric ``revision`` Bob considers the SCM as deterministic.

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -219,12 +219,12 @@ fi
     # Get GitSCM status. The purpose of this function is to return the status of the given directory
     #
     # return values:
-    #  - error: the scm is in a error state. Use this if git returned a error code.
-    #  - dirty: SCM is dirty. Could be: modified files, switched to another branch/tag/commit/repo, unpushed commits
-    #  - clean: same branch/tag/commit as specified in the recipe and no local changes.
-    #  - empty: directory is not existing
+    #  - error: The SCM is in a error state. Use this if git returned a error code.
+    #  - dirty: SCM is dirty. Could be: modified files, switched to another branch/tag/commit/repo, unpushed commits.
+    #  - clean: Same branch/tag/commit as specified in the recipe and no local changes.
+    #  - empty: Directory is not existing.
     #
-    # This function is called when build with --clean-checkou. 'error' and 'dirty' scm's are moved to attic,
+    # This function is called when build with --clean-checkout. 'error' and 'dirty' SCMs are moved to attic,
     # while empty and clean directories are not.
     def status(self, workspacePath, dir):
         scmdir = os.path.join(workspacePath, dir)


### PR DESCRIPTION
**Problem this is trying to solve:**
Each time a new source directory is created, because of new tags or branches, or because of creating a new "workspace", i.e. cloning the recipe repository to a new location, the user has to re-add his personal remote repositories.

**Solution:**
Add a `scmOverride` with the users remotes that will be added each time the corresponding repositories are checked out. This would look something like:
```yaml
# file: default.yaml
scmOverride:
    match:
        url: "git@central/repo/url.git"
    remotes:
        my_remote: "git@my/remote/url.git"
        second_developer: "git@second/developers/url.git"
```
The key will be used as the remote name and the value as the remote URL.

This is a quick implementation to see if it works as expected. And it seems that it does.

So is this something you would consider to merge? If it is, I would go ahead and add documentation and care for corner-case, if there are any, etc. Or could this problem be solved differently?