### PR TITLE
doc: fix path to sandbox graph for htmldoc

### DIFF
--- a/doc/tutorial/compile.rst
+++ b/doc/tutorial/compile.rst
@@ -357,4 +357,4 @@ the zlib packages: ::
 .. _basement-project: https://github.com/BobBuildTool/basement
 .. raw:: html
 
-    <iframe src="../../_static/sandbox.html" height="500px" width="100%"></iframe>
+    <iframe src="../_static/sandbox.html" height="500px" width="100%"></iframe>


### PR DESCRIPTION
The path to the _static dir is different between 'dirhtml' and 'html'
doc build. Using the correct path for 'html' build which is the same as
readthedocs.