### PR TITLE
Add optimistic mode to drop the fsync.

### DIFF
--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -19,6 +19,7 @@ from .errors import BobError
 from .state import finalize
 from .tty import colorize, Unbuffered
 from .utils import asHexStr, hashDirectory
+from .state import BobState
 import argparse
 import sys
 import traceback
@@ -161,6 +162,7 @@ def bob(bobRoot):
         parser.add_argument('-C', '--directory', dest='directory', action='append', help="Change to DIRECTORY before doing anything", metavar="DIRECTORY")
         parser.add_argument('--version', dest='version', action='store_true', help="Show version")
         parser.add_argument('--debug',   dest='debug',   action='store_true', help="Enable debug mode")
+        parser.add_argument('--optimistic', dest='optimistic', action='store_true', help="Don't flush to disk (be optimistic)")
         parser.add_argument('-i', dest='ignore_commandCfg', default=False, action='store_true',
                 help="Use bob's default argument settings and do not use commands section of the userconfig.")
         parser.add_argument('command', nargs='?', help="Command to execute")
@@ -173,6 +175,9 @@ def bob(bobRoot):
 
         if args.debug:
             _enableDebug()
+
+        if args.optimistic:
+            BobState().setOptimistic()
 
         if args.ignore_commandCfg:
             from .input import RecipeSet

--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -39,6 +39,7 @@ class _BobState():
         self.__inputs = {}
         self.__jenkins = {}
         self.__asynchronous = 0
+        self.__optimistic = 0
         self.__dirty = False
         self.__dirStates = {}
         self.__buildState = {}
@@ -115,7 +116,8 @@ class _BobState():
                 with open(tmpFile, "wb") as f:
                     pickle.dump(state, f)
                     f.flush()
-                    os.fsync(f.fileno())
+                    if self.__optimistic == 0:
+                        os.fsync(f.fileno())
                 os.replace(tmpFile, self.__path)
             except OSError as e:
                 raise ParseError("Error saving workspace state: " + str(e))
@@ -147,6 +149,9 @@ class _BobState():
         assert self.__asynchronous >= 0
         if (self.__asynchronous == 0) and self.__dirty:
             self.__save()
+
+    def setOptimistic(self):
+        self.__optimistic += 1
 
     def getByNameDirectory(self, baseDir, digest, isSourceDir):
         if digest in self.__byNameDirs:


### PR DESCRIPTION
bob will quite often flush to disk using `fsync`. This overhead becomes significant when using small projects and a rotating hard disk.  The protection it provides is comparatively minor, because if the system actually crashes, object files created by the compiler will be in an indeterminate state anyway; the compiler does not do `fsync`.  Thus, this adds an option `--optimistic` to disable the `fsync`.

-----

I spent about three seconds to invent the name, better ideas are appreciated. I would actually remove the `fsync` completely, but didn't want to leap ahead so far already.