### PR TITLE
doc: fix wording of "recipes" directory

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -2,7 +2,7 @@ Configuration
 =============
 
 When building packages Bob executes the instructions defined by the recipes.
-All recipes are located relative to the working directory in the ``recipes``
+All recipes are located relative to the project root directory in the ``recipes``
 subdirectory. Recipes are YAML files with a defined structure. The name of the
 recipe and the resulting package(s) is derived from the file name by removing
 the trailing '.yaml'. To aid further organization of the recipes they may be
@@ -1096,7 +1096,7 @@ specified without the .yaml extension::
     from where includes are resolved is different. Normally files are included
     relative to the currently processed file unless the
     :ref:`policies-relativeIncludes` policy is disabled. In this case files
-    included by ``default.yaml`` and by the command line use the recipes
+    included by ``default.yaml`` and by the command line use the project root
     directory as base directory.
 
 .. _configuration-config-environment:
@@ -1339,7 +1339,7 @@ hooks
 
 Hooks are other programs or scripts that can be executed by Bob at certain
 points, e.g. before or after a build. Unless otherwise noted they are executed
-with the recipes directory as working directory. Example::
+with the project root directory as working directory. Example::
 
     hooks:
         postBuildHook: ./contrib/notify.sh

--- a/doc/manual/policies.rst
+++ b/doc/manual/policies.rst
@@ -134,8 +134,8 @@ processed file.
 
 Old behaviour
     Include further files from ``default.yaml`` and command line passed files
-    relative to the current recipes directory. Global configuration files use
-    the new policy in any case.
+    relative to the project root directory. Global configuration files use the
+    new policy in any case.
 
 New behaviour
     All files are included relative to the currently processed file.

--- a/doc/tutorial/compile.rst
+++ b/doc/tutorial/compile.rst
@@ -217,7 +217,7 @@ feature ``bob-namespace-sandbox`` must be available too. To keep the setup
 simple it is recommended to install Bob entirely on the server.
 
 Suppose you have a suitable Jenkins server located at
-http://jenkins.intranet.local:8080. Go to the recipes directory and tell Bob
+http://jenkins.intranet.local:8080. Go to the project root directory and tell Bob
 about your server and what you want to build there (substitute ``<user>`` and
 ``<pass>`` with your actual credentials)::
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2074,7 +2074,7 @@ class RecipeSet:
         self.__policies = {
             'relativeIncludes' : (
                 "0.13",
-                InfoOnce("relativeIncludes policy not set. Using recipes directory as base for all includes!",
+                InfoOnce("relativeIncludes policy not set. Using project root directory as base for all includes!",
                     help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#relativeincludes for more information.")
             ),
             'cleanEnvironment' : (


### PR DESCRIPTION
The word "recipes" was used interchangeably for the project root
directory (with config.yaml, default.yaml, recipes and classes
directory) and the "recipes" directory inside that itself. Solve this
ambiguity by using a consistent naming of the "project root directory"
which, among other things, contains the "recipes directory".

Fixes #163.