### PR TITLE
build: add forced-fallback download mode

### DIFF
--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -49,6 +49,8 @@ Options
       from sources (default for develop mode)
     forced-deps
       like 'deps' above, but fail if any download fails
+    forced-fallback
+      combination of forced and forced-deps modes: if forced fails fall back to forced-deps
 
 ``--incremental``
     Reuse build directory for incremental builds


### PR DESCRIPTION
With this mode it will be tried to download the desired package artifact at first. If this fails all dependency artifacts must be available