### PR TITLE
bob: don't add spaces after last PATH element

### DIFF
--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -106,7 +106,7 @@ def addBuildConfig(outFile, num, name, buildArgs, buildMeFile):
     outFile.write('<value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>\n')
     outFile.write('<value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>\n')
     outFile.write('<valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges">\n')
-    outFile.write(' <value type="QString">' + "PATH=" + os.environ['PATH'] + '  </value>\n')
+    outFile.write(' <value type="QString">' + "PATH=" + os.environ['PATH'] + '</value>\n')
     outFile.write('</valuelist>\n')
     outFile.write('<value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Vorgabe</value>\n')
     outFile.write('<value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">' + name + '</value>\n')


### PR DESCRIPTION
bob project qt-creator appends two spaces after the contents of the PATH
variable in QtCreator project file. This breaks the last component of the
PATH variable. E.g. it turns "foo:bar:baz" into "foo:bar:baz  " and
whatever would be found in "baz" will not be found when the PATH contains
"baz  " instead.

Remove the extra spaces.