### PR TITLE
Shared toolchain

### DIFF
--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -88,6 +88,12 @@ Options
 ``-f, --force``
     Force execution of all build steps
 
+``-i, --installshared``
+    Install shared packages to a given location (has to be combined with --shared)
+
+``-s, --shared PATH``
+    Shared packages will be searched at or installed to provided path
+
 ``-n, --no-deps``
     Don't build dependencies
 

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -987,7 +987,7 @@ esac
                         wasShared = True
                         workspaceChanged = True
                         packageHash = hashWorkspace(packageStep)
-                elif oldWasDownloadedorShared:
+                elif oldWasDownloadedOrShared:
                     self._info("   PACKAGE   skipped (deterministic output in {})".format(prettyPackagePath))
                     wasShared = True
 

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -280,7 +280,7 @@ esac
         return fmt
 
     def __init__(self, recipes, verbose, force, skipDeps, buildOnly, preserveEnv,
-                 envWhiteList, bobRoot, cleanBuild, noLogFile):
+                 envWhiteList, bobRoot, cleanBuild, noLogFile, sharedFolder, installShared):
         self.__recipes = recipes
         self.__wasRun= {}
         self.__wasSkipped = {}
@@ -302,6 +302,8 @@ esac
         self.__buildDistBuildIds = {}
         self.__statistic = LocalBuilderStatistic()
         self.__alwaysCheckout = []
+        self.__sharedFolder = sharedFolder
+        self.__installShared = installShared
 
     def setArchiveHandler(self, archive):
         self.__archive = archive
@@ -893,9 +895,16 @@ esac
             # Can we theoretically download the result? Exclude packages that
             # provide host tools when not building in a sandbox. Try to
             # determine a build-id for all other artifacts.
+            #
+            # Create build-id for shared packages, but don't download them
             if packageStep.doesProvideTools() and (packageStep.getSandbox() is None):
-                packageBuildId = None
+                if packageStep.isShared() and self.__sharedFolder:
+                    canDownload = False
+                    packageBuildId = self._getBuildId(packageStep, depth)
+                else:
+                    packageBuildId = None
             else:
+                canDownload = True
                 packageBuildId = self._getBuildId(packageStep, depth)
 
             # If we download the package in the last run the Build-Id is stored
@@ -906,14 +915,14 @@ esac
             if (isinstance(oldInputBuildId, list) and (len(oldInputBuildId) >= 1)):
                 oldInputHashes = oldInputBuildId[1:]
                 oldInputBuildId = oldInputBuildId[0]
-                oldWasDownloaded = False
+                oldWasDownloadedOrShared = False
             elif isinstance(oldInputBuildId, bytes):
-                oldWasDownloaded = True
+                oldWasDownloadedOrShared = True
                 oldInputHashes = None
             else:
                 # created by old Bob version or new workspace
                 oldInputHashes = oldInputBuildId
-                oldWasDownloaded = False
+                oldWasDownloadedOrShared = False
 
             # If possible try to download the package. If we downloaded the
             # package in the last run we have to make sure that the Build-Id is
@@ -928,7 +937,8 @@ esac
             #   build-id changed -> prune and try download, fall back to build
             workspaceChanged = False
             wasDownloaded = False
-            if ( (not checkoutOnly) and packageBuildId and (depth >= self.__downloadDepth) ):
+            wasShared = False
+            if ( (not checkoutOnly) and packageBuildId and (depth >= self.__downloadDepth) ) and canDownload:
                 # prune directory if we previously downloaded/built something different
                 if ((oldInputBuildId is not None) and (oldInputBuildId != packageBuildId)) or self.__force:
                     print(colorize("   PRUNE     {} ({})".format(prettyPackagePath,
@@ -952,15 +962,41 @@ esac
                         wasDownloaded = True
                     elif depth >= self.__downloadDepthForce:
                         raise BuildError("Downloading artifact failed")
-                elif oldWasDownloaded:
+                elif oldWasDownloadedOrShared:
                     self._info("   PACKAGE   skipped (already downloaded in {})".format(prettyPackagePath))
                     wasDownloaded = True
+
+            if packageStep.isShared() and self.__sharedFolder and not wasDownloaded:
+                if BobState().getResultHash(prettyPackagePath) is None:
+                    sharedpackagepath = os.path.join(self.__sharedFolder, asHexStr(packageBuildId))
+                    # link into dist if shared package available
+                    if self._checkSharedPackage(packageStep, asHexStr(packageBuildId)):
+                        print(colorize("     Link from shared location {}".format(sharedpackagepath), "32"))
+                        dirlist = os.listdir(sharedpackagepath)
+                        cwd = os.getcwd()
+                        os.chdir(prettyPackagePath)
+                        for item in dirlist:
+                            if item == '.installed':
+                                continue
+                            itempath = os.path.join(sharedpackagepath, item)
+                            if item in ['env', 'audit.json.gz']:
+                                os.symlink(itempath, os.path.join(os.getcwd(), '..', item))
+                            else:
+                                os.symlink(itempath, item, os.path.isdir(itempath))
+                        os.chdir(cwd)
+                        wasShared = True
+                        workspaceChanged = True
+                        packageHash = hashWorkspace(packageStep)
+                elif oldWasDownloadedorShared:
+                    self._info("   PACKAGE   skipped (deterministic output in {})".format(prettyPackagePath))
+                    wasShared = True
+
 
             # Run package step if we have not yet downloaded the package or if
             # downloads are not possible anymore. Even if the package was
             # previously downloaded the oldInputHashes will be None to trigger
             # an actual build.
-            if not wasDownloaded:
+            if not wasDownloaded and not wasShared:
                 # depth first
                 self._cook(packageStep.getAllDepSteps(), packageStep.getPackage(),
                            checkoutOnly, depth+1)
@@ -980,15 +1016,29 @@ esac
                     self._runShell(packageStep, "package")
                     packageHash = hashWorkspace(packageStep)
                     audit = self._generateAudit(packageStep, depth, packageHash)
+                    # copy to shared location if possible
+                    if self.__installShared and packageStep.isShared():
+                        sharedpackagepath = os.path.join(self.__sharedFolder, asHexStr(packageBuildId))
+                        print(colorize("     Install in shared location {}".format(sharedpackagepath), "32"))
+                        if os.path.exists(sharedpackagepath):
+                            shutil.rmtree(sharedpackagepath)
+                        # copy all files from workspace - keep symlinks
+                        shutil.copytree(prettyPackagePath, sharedpackagepath, symlinks=True)
+                        # copy env file - important for audit
+                        shutil.copy2(os.path.join(prettyPackagePath, '..', 'env'), sharedpackagepath)
+                        shutil.copy2(os.path.join(prettyPackagePath, '..', 'audit.json.gz'), sharedpackagepath)
+                        open(os.path.join(sharedpackagepath, '.installed'), 'a').close()
                     workspaceChanged = True
                     self.__statistic.packagesBuilt += 1
                     if packageBuildId and self.__archive.canUploadLocal():
-                        self.__archive.uploadPackage(packageBuildId, audit, prettyPackagePath, self.__verbose)
+                        if not (packageStep.doesProvideTools() and (packageStep.getSandbox() is None)):
+                            self.__archive.uploadPackage(packageBuildId, audit, prettyPackagePath, self.__verbose)
+
 
             # Rehash directory if content was changed
             if workspaceChanged:
                 BobState().setResultHash(prettyPackagePath, packageHash)
-                if wasDownloaded:
+                if wasDownloaded or wasShared:
                     BobState().setInputHashes(prettyPackagePath, packageBuildId)
                 else:
                     BobState().setInputHashes(prettyPackagePath, [packageBuildId] + packageInputHashes)
@@ -1085,6 +1135,13 @@ esac
             predicted = True
 
         return ret, predicted
+
+    def _checkSharedPackage(self, step, packageBuildId):
+         sharedPackagePath = os.path.join(self.__sharedFolder, packageBuildId)
+         if os.path.isdir(sharedPackagePath):
+             if os.path.exists(os.path.join(sharedPackagePath, '.installed')):
+                 return True
+         return False
 
     def _getBuildId(self, step, depth):
         """Calculate build-id and cache result.
@@ -1273,7 +1330,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
     builder = LocalBuilder(recipes, cfg.get('verbosity', 0) + args.verbose - args.quiet, args.force,
                            args.no_deps, True if args.build_mode == 'build-only' else False,
                            args.preserve_env, envWhiteList, bobRoot, args.clean,
-                           args.no_logfiles)
+                           args.no_logfiles, args.shared, args.installshared)
 
     builder.setArchiveHandler(getArchiver(recipes))
     builder.setUploadMode(args.upload)

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2051,6 +2051,7 @@ class RecipeSet:
                 schema.Optional('preBuildHook') : str,
                 schema.Optional('postBuildHook') : str,
             }),
+            schema.Optional('sharedFolder') : str,
         })
 
     STATIC_CONFIG_SCHEMA = schema.Schema({
@@ -2097,6 +2098,7 @@ class RecipeSet:
             ),
         }
         self.__buildHooks = {}
+        self.__sharedFolder = ""
 
     def __addRecipe(self, recipe):
         name = recipe.getPackageName()
@@ -2242,6 +2244,9 @@ class RecipeSet:
     def getBuildHook(self, name):
         return self.__buildHooks.get(name)
 
+    def getSharedFolder(self):
+        return self.__sharedFolder
+
     def loadBinary(self, path):
         return self.__cache.loadBinary(path)
 
@@ -2286,7 +2291,6 @@ class RecipeSet:
         self.__parseUserConfig(os.path.join(os.environ.get('XDG_CONFIG_HOME',
             os.path.join(os.path.expanduser("~"), '.config')), 'bob', 'default.yaml'), True)
         self.__parseUserConfig("default.yaml")
-
         # finally parse recipes
         for root, dirnames, filenames in os.walk('classes'):
             for path in fnmatch.filter(filenames, "*.yaml"):
@@ -2336,6 +2340,7 @@ class RecipeSet:
         if not self._ignoreCmdConfig:
             self.__commandConfig = updateDicRecursive(self.__commandConfig, cfg.get("command", {}))
         self.__buildHooks.update(cfg.get("hooks", {}))
+        self.__sharedFolder = cfg.get("sharedFolder", self.__sharedFolder)
         for p in cfg.get("include", []):
             p = os.path.join(os.path.dirname(fileName), p) if relativeIncludes else p
             self.__parseUserConfig(p + ".yaml", relativeIncludes)

--- a/test/relocatable/config.yaml
+++ b/test/relocatable/config.yaml
@@ -1,0 +1,3 @@
+bobMinimumVersion: "0.13"
+plugins:
+    - "checkPackages"

--- a/test/relocatable/plugins/checkPackages.py
+++ b/test/relocatable/plugins/checkPackages.py
@@ -1,0 +1,22 @@
+from bob.errors import ParseError
+
+# check if packages are relocatable or not
+
+def _checkPackages(step):
+    if step.isValid() and step.isPackageStep():
+        if not step.isPackageRelocatable() and step.getPackage().getName() == 'some-tool-relocatable':
+            raise ParseError('Package some-tool-relocatable should be relocatable!')
+        if step.isPackageRelocatable() and step.getPackage().getName() == 'some-tool':
+            raise ParseError('Package ' + step.getPackage().getName() + 'shouldn\'t be relocatable!')
+    for s in step.getAllDepSteps():
+        _checkPackages(s)
+
+def checkPackages(package, argv, extra):
+    _checkPackages(package.getPackageStep())
+
+manifest = {
+    'apiVersion' : "0.13",
+    'projectGenerators' : {
+        "checkPackages" : checkPackages
+    }
+}

--- a/test/relocatable/plugins/checkPackages.py
+++ b/test/relocatable/plugins/checkPackages.py
@@ -4,9 +4,9 @@ from bob.errors import ParseError
 
 def _checkPackages(step):
     if step.isValid() and step.isPackageStep():
-        if not step.isPackageRelocatable() and step.getPackage().getName() == 'some-tool-relocatable':
+        if not step.isRelocatable() and step.getPackage().getName() == 'some-tool-relocatable':
             raise ParseError('Package some-tool-relocatable should be relocatable!')
-        if step.isPackageRelocatable() and step.getPackage().getName() == 'some-tool':
+        if step.isRelocatable() and step.getPackage().getName() == 'some-tool':
             raise ParseError('Package ' + step.getPackage().getName() + 'shouldn\'t be relocatable!')
     for s in step.getAllDepSteps():
         _checkPackages(s)

--- a/test/relocatable/recipes/app.yaml
+++ b/test/relocatable/recipes/app.yaml
@@ -1,0 +1,12 @@
+depends:
+    - lib
+    - pack
+
+checkoutScript: |
+    echo "app" > source.txt
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/relocatable/recipes/lib.yaml
+++ b/test/relocatable/recipes/lib.yaml
@@ -1,0 +1,10 @@
+checkoutTools: [some-tool]
+
+checkoutScript: |
+    some-tool > source.txt
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/relocatable/recipes/pack.yaml
+++ b/test/relocatable/recipes/pack.yaml
@@ -1,0 +1,10 @@
+checkoutTools: [some-tool-relocatable]
+
+checkoutScript: |
+    some-tool-relocatable > source.txt
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/relocatable/recipes/root.yaml
+++ b/test/relocatable/recipes/root.yaml
@@ -1,0 +1,18 @@
+root: True
+
+depends:
+    -
+        name: some-tool
+        use: [tools]
+        forward: True
+    -
+        name: some-tool-relocatable
+        use: [tools]
+        forward: True
+    - app
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/relocatable/recipes/some-tool-relocatable.yaml
+++ b/test/relocatable/recipes/some-tool-relocatable.yaml
@@ -1,0 +1,18 @@
+packageRelocatable: True
+shared: True
+
+checkoutScript: |
+    cat >some-tool-relocatable <<EOF
+    echo "Greetz from some-tool-relocatable"
+    EOF
+    chmod +x some-tool-relocatable
+checkoutDeterministic: True
+
+buildScript: |
+    cp $1/some-tool-relocatable .
+
+packageScript: |
+    cp $1/some-tool-relocatable .
+
+provideTools:
+    some-tool-relocatable: .

--- a/test/relocatable/recipes/some-tool-relocatable.yaml
+++ b/test/relocatable/recipes/some-tool-relocatable.yaml
@@ -1,4 +1,4 @@
-packageRelocatable: True
+relocatable: True
 shared: True
 
 checkoutScript: |

--- a/test/relocatable/recipes/some-tool.yaml
+++ b/test/relocatable/recipes/some-tool.yaml
@@ -1,0 +1,14 @@
+checkoutScript: |
+    cat >some-tool <<EOF
+    echo "Greetz from some-tool"
+    EOF
+    chmod +x some-tool
+
+buildScript: |
+    cp $1/some-tool .
+
+packageScript: |
+    cp $1/some-tool .
+
+provideTools:
+    some-tool: .

--- a/test/relocatable/run.sh
+++ b/test/relocatable/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Test that --checkout-only does what it says. Additionally it checks that
+# tools that are used during a checkout step are still built.
+
+# checkout sources
+run_bob project -n checkPackages root


### PR DESCRIPTION
Installs packages (toolchains) to a defined folder (global, different from workspace), packages installed to this folder can be re-used by any workspace.

    recipes with "shared: True" and provideTools are affected

    after building successfully the dist-directory, env and audit.tgz will be copied into a selected folder (specified with "-i" for install, and --shared for destination)

    with "--shared" toolchains will be linked into the workspace instead of built again

    advantage:
        less initial build time for new workspaces
        can be used with jenkins

Attention: will not be working with non-relocatable toolchains