### PR TITLE
project: add --release and --develop (default) mode to switch between name formatter

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -13,7 +13,7 @@ Synopsis
 
 ::
 
-    bob project [-h] [--list] [-D DEFINES] [-c CONFIGFILE] [-e NAME] [-E]
+    bob project [-h] [--develop | --release] [--list] [-D DEFINES] [-c CONFIGFILE] [-e NAME] [-E]
                 [--resume] [-n] [-b]
                 [projectGenerator] [package] ...
 
@@ -32,6 +32,9 @@ Options
 ``-D DEFINES``
     Override default environment variable
 
+``--develop``
+    Use developer mode. This is default.
+
 ``-e NAME``
     Preserve environment variable
 
@@ -47,6 +50,9 @@ Options
 
 ``-b``
     Do build only (bob dev -b) before generate project Files. No checkout
+
+``--release``
+    Use release mode
 
 ``--resume``
     Resume build where it was previously interrupted

--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -1374,6 +1374,9 @@ def doProject(argv, bobRoot):
         help="Enable sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--develop', action='store_true',  dest='develop', help="Use developer mode", default=True)
+    group.add_argument('--release', action='store_false', dest='develop', help="Use release mode")
     args = parser.parse_args(argv)
 
     defines = {}
@@ -1387,6 +1390,7 @@ def doProject(argv, bobRoot):
             parser.error("Malformed define: "+define)
 
     recipes = RecipeSet()
+    recipes.defineHook('releaseNameFormatter', LocalBuilder.releaseNameFormatter)
     recipes.defineHook('developNameFormatter', LocalBuilder.developNameFormatter)
     recipes.defineHook('developNamePersister', LocalBuilder.developNamePersister)
     recipes.setConfigFiles(args.configFile)
@@ -1395,9 +1399,13 @@ def doProject(argv, bobRoot):
     envWhiteList = recipes.envWhiteList()
     envWhiteList |= set(args.white_list)
 
-    nameFormatter = recipes.getHook('developNameFormatter')
-    developPersister = recipes.getHook('developNamePersister')
-    nameFormatter = developPersister(nameFormatter)
+    if args.develop:
+        nameFormatter = recipes.getHook('developNameFormatter')
+        developPersister = recipes.getHook('developNamePersister')
+        nameFormatter = developPersister(nameFormatter)
+    else:
+        nameFormatter = recipes.getHook('releaseNameFormatter')
+        nameFormatter = LocalBuilder.releaseNamePersister(nameFormatter)
     nameFormatter = LocalBuilder.makeRunnable(nameFormatter)
     packages = recipes.generatePackages(nameFormatter, defines, sandboxEnabled=args.sandbox)
     touch(packages)


### PR DESCRIPTION
For some plug-ins it would be useful if you can fetch the workspace for "bob build"-built projects.