### PR TITLE
bob: handle Windows more thoroughly

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -21,7 +21,8 @@ from ..errors import BobError, BuildError, ParseError
 from ..input import RecipeSet
 from ..state import BobState
 from ..tty import colorize
-from ..utils import asHexStr, hashDirectory, hashFile, removePath, emptyDirectory, copyTree
+from ..utils import asHexStr, hashDirectory, hashFile, removePath, \
+    emptyDirectory, copyTree, isWindows
 from datetime import datetime
 from glob import glob
 from pipes import quote
@@ -447,7 +448,7 @@ esac
         """Create symlinks to the dependency workspaces"""
 
         # this will only work on POSIX
-        if os.name != 'posix': return
+        if isWindows(): return
 
         # always re-create the deps directory
         basePath = os.getcwd()

--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -107,6 +107,19 @@ def compareVersion(origLeft, origRight):
         raise ParseError("Cannot compare version numbers ('{}' vs. '{}'): bad format!"
                             .format(origLeft, origRight))
 
+def isWindows():
+    """Check if we run on a windows platform.
+
+    We have to rule out MSYS(2) and Cygwin as they are advertised a POSIX but
+    in fact cannot truly hide the underlying system.
+    """
+    if os.name == 'posix':
+        p = sys.platform
+        if p.startswith('msys'): return True
+        if p.startswith('cygwin'): return True
+        return False
+    return True
+
 ### directory hashing ###
 
 def hashFile(path):


### PR DESCRIPTION
When run under MSYS or Cygwin the OS will be advertised as POSIX. This
is not fully correct because sym- or hard-links are not really working.
Detect these as Windows platform too and fall back to more generic
behaviour.

Fixes #179.