### PR TITLE
Convert shell startscripts to python

### DIFF
--- a/bob
+++ b/bob
@@ -1,6 +1,12 @@
-#!/bin/sh
-D="$(dirname "$(readlink -f "${0}")")"
-export PYTHONPATH="$D/pym:${PYTHONPATH}"
-exec python3 -c "import sys
+#!/usr/bin/env python3
+
+import os
+import sys
+
+scr_path = os.path.dirname(os.path.realpath(__file__))
+pym_path = os.path.join(scr_path, 'pym')
+sys.path.insert(0, pym_path)
+
 from bob.scripts import bob
-sys.exit(bob(\"$D\"))" "$@"
+
+sys.exit(bob(scr_path))

--- a/bob-audit-engine
+++ b/bob-audit-engine
@@ -1,7 +1,13 @@
-#!/bin/sh
-D="$(dirname "$(readlink -f "${0}")")"
-export PYTHONPATH="$D/pym:${PYTHONPATH}"
-exec python3 -c "import sys
+#!/usr/bin/env python3
+
+import os
+import sys
+
+scr_path = os.path.dirname(os.path.realpath(__file__))
+pym_path = os.path.join(scr_path, 'pym')
+sys.path.insert(0, pym_path)
+
 from bob.scripts import auditEngine
-sys.argv[0] = '${0##*/}'
-sys.exit(auditEngine())" "$@"
+
+sys.argv[0] = os.path.basename(sys.argv[0])
+sys.exit(auditEngine())

--- a/bob-hash-engine
+++ b/bob-hash-engine
@@ -1,7 +1,13 @@
-#!/bin/sh
-D="$(dirname "$(readlink -f "${0}")")"
-export PYTHONPATH="$D/pym:${PYTHONPATH}"
-exec python3 -c "import sys
+#!/usr/bin/env python3
+
+import os
+import sys
+
+scr_path = os.path.dirname(os.path.realpath(__file__))
+pym_path = os.path.join(scr_path, 'pym')
+sys.path.insert(0, pym_path)
+
 from bob.scripts import hashEngine
-sys.argv[0] = '${0##*/}'
-sys.exit(hashEngine())" "$@"
+
+sys.argv[0] = os.path.basename(sys.argv[0])
+sys.exit(hashEngine())

--- a/bob-hash-tree
+++ b/bob-hash-tree
@@ -1,7 +1,13 @@
-#!/bin/sh
-D="$(dirname "$(readlink -f "${0}")")"
-export PYTHONPATH="$D/pym:${PYTHONPATH}"
-exec python3 -c "import sys
+#!/usr/bin/env python3
+
+import os
+import sys
+
+scr_path = os.path.dirname(os.path.realpath(__file__))
+pym_path = os.path.join(scr_path, 'pym')
+sys.path.insert(0, pym_path)
+
 from bob.scripts import hashTree
-sys.argv[0] = '${0##*/}'
-sys.exit(hashTree())" "$@"
+
+sys.argv[0] = os.path.basename(sys.argv[0])
+sys.exit(hashTree())


### PR DESCRIPTION
With this change it's now possible to use debug and other wrapping applications like the profiler:

```
python3 -m cProfile -o bob-ls.stats $BOB_PATH/bob ls
gprof2dot -f pstats bob-ls.stats | dot -Tpng -o bob-ls.png
```

Since we don't use the other start scripts, I have only testet `bob`.

While we are at it? Why are the other scripts not part of the normal bob runtime and implemented as subcommands?