### PR TITLE
jenkins: make a stable job configuration

### DIFF
--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -396,7 +396,7 @@ class JenkinsJob:
             "-D", "jenkins-node", '"$NODE_NAME"',
             "-D", "jenkins-build-url", '"$BUILD_URL"'
         ]
-        for (var, val) in step.getPackage().getMetaEnv().items():
+        for (var, val) in sorted(step.getPackage().getMetaEnv().items()):
             cmd.extend(["-E", var, quote(val)])
         recipesAudit = step.getPackage().getRecipe().getRecipeSet().getScmAudit()
         if recipesAudit is not None:


### PR DESCRIPTION
Sort the meta environment variables to get a stable job description.
This will avoid setting a new configuration for a unchanged input which
sometimes takes a very long time.