### PR TITLE
build: fix KeyError in loadBuildState

### DIFF
--- a/pym/bob/cmds/build.py
+++ b/pym/bob/cmds/build.py
@@ -474,9 +474,9 @@ esac
 
     def loadBuildState(self):
         state = BobState().getBuildState()
-        self.__wasRun = dict(state['wasRun'])
+        self.__wasRun = dict(state.get('wasRun', {}))
         self.__srcBuildIds = { (path, vid) : (bid, True)
-            for (path, vid), bid in state['predictedBuidId'].items() }
+            for (path, vid), bid in state.get('predictedBuidId', {}).items() }
 
     def _wasAlreadyRun(self, step, skippedOk=False):
         path = step.getWorkspacePath()


### PR DESCRIPTION
Fix KeyError occurring on a bob dev/build --resume without having a valid
.bob-state / bob was not run before.