### PR TITLE
scmOverrides: allow use of variables

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1390,6 +1390,10 @@ If an override is matching the actions are then applied in the following order:
    ``replacement``. Each occurrence of ``pattern`` is replaced by
    ``replacement``.
 
+All overrides values are mangled through :ref:`configuration-principle-subst`. Mangling is
+performed during calculation of the checkoutStep so that the full environment for this step is
+available for substitution.
+
 alias
 ~~~~~
 

--- a/doc/releases/0.14.rst
+++ b/doc/releases/0.14.rst
@@ -43,6 +43,10 @@ New features
   Now it is possible to add such paths to ``default.yaml``. See
   :ref:`configuration-config-sandbox`.
 
+* Allow substitution on scmOverrides
+
+   The values of scmOverrides are mangled through :ref:`configuration-principle-subst`.
+
 Recipes
 ~~~~~~~
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -283,7 +283,7 @@ def Scm(spec, env, overrides, recipeSet):
     # apply overrides before creating scm instances. It's possible to switch the Scm type with an override..
     matchedOverrides = []
     for override in overrides:
-        matched, spec = override.mangle(spec)
+        matched, spec = override.mangle(spec, env)
         if matched:
             matchedOverrides.append(override)
 


### PR DESCRIPTION
Override scms having a common used set of overrides controlled by variables.

This reduces the number of overrides needed when you entered branching hell for your project... :see_no_evil: :hear_no_evil:

I'm not sure if it's a good idea to do the substitution only with the environment from `default.yaml` / command line but I have the feeling that substitution when constructing the `CheckoutStep` using the `fullEnv` is too late. It gives the recipes the possibility to change to override again which might be a pitfall.  :confused: