### PR TITLE
scripts: give feedback when stopping execution

### DIFF
--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -126,6 +126,7 @@ def catchErrors(fun, *args, **kwargs):
         print(e, file=sys.stderr)
         ret = 1
     except KeyboardInterrupt:
+        print(colorize("Stopping execution. (Don't press Ctrl+C again!)", "32;1"))
         ret = 2
     except ImportError as e:
         if e.name:


### PR DESCRIPTION
As stopping bob could take some time (write the state) give some
feedback that bob is stopping. Otherwise many users press ctrl+c
again leading to a incomplete written state.