### PR TITLE
url: tar: use consistent permissions

### DIFF
--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -40,7 +40,7 @@ class UrlScm(Scm):
     ]
 
     EXTRACTORS = {
-        "tar"  : ("tar xf", "--strip-components={}"),
+        "tar"  : ("tar -x --no-same-owner --no-same-permissions -f", "--strip-components={}"),
         "gzip" : ("gunzip -kf", None),
         "xz"   : ("unxz -kf", None),
         "7z"   : ("7z x -y", None),


### PR DESCRIPTION
Add two flags to `tar` invocation that will provide consistent behavior
whether `bob` is executed as root or a normal user.