### PR TITLE
Improve parsing speed and memory consumption

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -296,8 +296,6 @@ The following built in string functions are supported:
   ``then`` is returned. Otherwise ``else`` is returned.
 * ``$(is-sandbox-enabled)``: Return ``true`` if a sandbox is enabled in the
   current context, ``false`` otherwise.
-* ``$(is-tool-defined,name)``: If ``name`` is a defined tool in the current
-  context the function will return ``true``. Otherwise ``false`` is returned.
 * ``$(ne,left,right)``: Returns ``true`` if the expansions of ``left`` and
   ``right`` differ, otherwise ``false`` is returned.
 * ``$(not,condition)``: Interpret the expansion of ``condition`` as boolean

--- a/doc/manual/extending.rst
+++ b/doc/manual/extending.rst
@@ -172,9 +172,8 @@ passed:
 
 * ``env``: dict of all available environment variables at the current context
 * ``recipe``: the current :class:`bob.input.Recipe`
-* ``sandbox``: an instance of :class:`bob.input.Sandbox` of the current context
-  or ``None`` if no sandbox was configured
-* ``tools``: dict of all available tools (see :class:`bob.input.Tool`)
+* ``sandbox``: ``True`` if a sandbox is used. ``False`` if no sandbox was
+  configured or if it is disabled (e.g. ``--no-sandbox`` option was specified).
 
 In the future additional keyword args may be added without notice. Such string
 functions should therefore have a catch-all ``**kwargs`` parameter. A sample implementation

--- a/pym/bob/__init__.py
+++ b/pym/bob/__init__.py
@@ -37,9 +37,9 @@ def getVersion():
 
     if not version:
         # Last fallback. See http://semver.org/ and adjust accordingly.
-        version = "0.15-dev"
+        version = "unknown"
 
-    return version
+    return "0.15-dev-" + version
 
 def getBobInputHash():
     from .utils import hashDirectory

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -700,6 +700,14 @@ class CoreStep(CoreItem):
             for p in providedSandbox.paths:
                 h.update(struct.pack("<I", len(p)))
                 h.update(p.encode('utf8'))
+            h.update(struct.pack("<I", len(providedSandbox.mounts)))
+            for (mntFrom, mntTo, mntOpts) in providedSandbox.mounts:
+                h.update(struct.pack("<III", len(mntFrom), len(mntTo), len(mntOpts)))
+                h.update((mntFrom+mntTo+"".join(mntOpts)).encode('utf8'))
+            h.update(struct.pack("<I", len(providedSandbox.environment)))
+            for (key, val) in sorted(providedSandbox.environment.items()):
+                h.update(struct.pack("<II", len(key), len(val)))
+                h.update((key+val).encode('utf8'))
         else:
             h.update(b'\x00' * 20)
 

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -301,7 +301,8 @@ class Env(MutableMapping):
         self.touched = self.touched + [ set() ]
 
     def touch(self, keys):
-        for k in keys: self.__touch(k)
+        for i in self.touched:
+            i.update(keys)
 
     def touchedKeys(self):
         return self.touched[-1]
@@ -366,7 +367,7 @@ def funStrip(args, **options):
 
 def funSandboxEnabled(args, sandbox, **options):
     if len(args) != 0: raise ParseError("is-sandbox-enabled expects no arguments")
-    return "true" if ((sandbox is not None) and sandbox.isEnabled()) else "false"
+    return "true" if sandbox else "false"
 
 def funToolDefined(args, tools, **options):
     if len(args) != 1: raise ParseError("is-tool-defined expects one argument")

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -4,10 +4,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .errors import ParseError
+from .tty import WarnOnce
 from collections.abc import MutableMapping
 from types import MappingProxyType
 import fnmatch
 import re
+
+isToolDefinedDeprecated = WarnOnce("Recipe uses deprecated 'is-tool-defined' function. Will always evaluate to 'false'!")
 
 def checkGlobList(name, allowed):
     if allowed is None: return True
@@ -369,9 +372,10 @@ def funSandboxEnabled(args, sandbox, **options):
     if len(args) != 0: raise ParseError("is-sandbox-enabled expects no arguments")
     return "true" if sandbox else "false"
 
-def funToolDefined(args, tools, **options):
+def funToolDefined(args, recipe, **options):
     if len(args) != 1: raise ParseError("is-tool-defined expects one argument")
-    return "true" if (args[0] in tools) else "false"
+    isToolDefinedDeprecated.warn(recipe.getName())
+    return "false"
 
 def funMatchScm(args, **options):
     if len(args) != 2: raise ParseError("matchScm expects two arguments")

--- a/pym/bob/tty.py
+++ b/pym/bob/tty.py
@@ -20,13 +20,14 @@ class Unbuffered(object):
     def __getattr__(self, attr):
         return getattr(self.stream, attr)
 
-class ShowOnce:
-    def __init__(self, slogan, color, message, help):
+class Show:
+    def __init__(self, slogan, color, message, help, onlyOnce=False):
         self.__slogan = slogan
         self.__color = color
         self.__message = message
         self.__help = help
         self.__triggered = False
+        self.__onlyOnce = onlyOnce
 
     def show(self, location=None):
         if not self.__triggered:
@@ -36,18 +37,26 @@ class ShowOnce:
                 file=sys.stderr)
             if self.__help:
                 print(self.__help, file=sys.stderr)
-            self.__triggered = True
+            self.__triggered = self.__onlyOnce
 
-class InfoOnce(ShowOnce):
-    def __init__(self, message, help=None):
-        super().__init__("INFO", "34", message, help)
+class Info(Show):
+    def __init__(self, message, help=None, onlyOnce=False):
+        super().__init__("INFO", "34", message, help, onlyOnce)
 
-class WarnOnce(ShowOnce):
+class InfoOnce(Info):
     def __init__(self, message, help=None):
-        super().__init__("WARNING", "33", message, help)
+        super().__init__(message, help, True)
+
+class Warn(Show):
+    def __init__(self, message, help=None, onlyOnce=False):
+        super().__init__("WARNING", "33", message, help, onlyOnce)
 
     def warn(self, location=None):
         super().show(location)
+
+class WarnOnce(Warn):
+    def __init__(self, message, help=None):
+        super().__init__(message, help, True)
 
 # module initialization
 

--- a/test/test_input_recipe.py
+++ b/test/test_input_recipe.py
@@ -169,7 +169,7 @@ class TestRelocatable(TestCase):
         r["root"] = True
         ret = Recipe(recipeSet, recipe, name+".yaml", cwd, name, name, {})
         ret.resolveClasses()
-        return ret.prepare(None, Env({}), False, {})[0]
+        return ret.prepare(Env(), False, {})[0].refDeref([], {}, None, None)
 
     def testNormalRelocatable(self):
         """Normal recipes are relocatable by default"""

--- a/test/test_input_step.py
+++ b/test/test_input_step.py
@@ -6,7 +6,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from bob.input import Env, CheckoutStep, BuildStep, PackageStep
+from bob.input import Env, CoreCheckoutStep, CoreBuildStep, CorePackageStep
 
 class Empty:
     pass
@@ -22,180 +22,167 @@ class MockRecipe:
         return MockRecipeSet()
 
     checkoutAsserts = []
+    toolDepCheckout = set(["a", "zz"])
+    toolDepBuild = set(["a", "zz"])
+    toolDepPackage = set(["a", "zz"])
 
-class MockPackage:
+class MockCorePackage:
     def __init__(self, checkoutScript="script", checkoutDigestScript="digest",
-            checkoutDeterministic=True):
+            checkoutDeterministic=True, tools={}):
         self.name = "package"
         self.recipe = MockRecipe()
         self.recipe.checkoutScript = checkoutScript
         self.recipe.checkoutDigestScript = checkoutDigestScript
         self.recipe.checkoutDeterministic = checkoutDeterministic
+        self.tools = tools
+        self.sandbox = None
 
     def getName(self):
         return self.name
 
-    def getRecipe(self):
-        return self.recipe
+    def refDeref(self, stack, inputTools, inputSandbox, pathFormatter):
+        return MockPackage()
 
-    def _getCorePackage(self):
-        return None
+class MockPackage:
+    def _setCheckoutStep(self, step):
+        pass
+    def _setBuildStep(self, step):
+        pass
+    def _setPackageStep(self, step):
+        pass
 
-nullPkg = MockPackage()
+nullPkg = MockCorePackage()
 nullFmt = lambda s,t: ""
 
 
 class TestCheckoutStep(TestCase):
     def testStereotype(self):
         """Check that the CheckoutStep identifies itself correctly"""
-        s = CheckoutStep()
-        s.construct(nullPkg, nullFmt)
+        s = CoreCheckoutStep(nullPkg).refDeref([], {}, None, nullFmt)
         assert s.isCheckoutStep() == True
         assert s.isBuildStep() == False
         assert s.isPackageStep() == False
 
     def testTrivialDeterministic(self):
         """Trivial steps are deterministic"""
-        s = CheckoutStep()
-        s.construct(nullPkg, nullFmt)
+        s = CoreCheckoutStep(nullPkg).refDeref([], {}, None, nullFmt)
         assert s.isDeterministic()
 
     def testTrivialInvalid(self):
         """Trivial steps are invalid"""
-        s = CheckoutStep()
-        s.construct(nullPkg, nullFmt)
+        s = CoreCheckoutStep(nullPkg).refDeref([], {}, None, nullFmt)
         assert s.isValid() == False
 
     def testDigestStable(self):
         """Same input should yield same digest"""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             Env({"a" : "asdf", "q": "qwer" }), Env({ "a" : "asdf" }))
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             Env({"a" : "asdf", "q": "qwer" }), Env({ "a" : "asdf" }))
-        assert s1.getVariantId() == s2.getVariantId()
+        assert s1.variantId == s2.variantId
 
     def testDigestScriptChange(self):
         """Script does influnce the digest"""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             Env({"a" : "asdf", "q": "qwer" }), Env({ "a" : "asdf" }))
-        s2 = CheckoutStep()
-        evilPkg = MockPackage(checkoutScript="evil", checkoutDigestScript="other digest")
-        s2.construct(evilPkg, nullFmt, None, ("evil", "other digest", [], []),
+        evilPkg = MockCorePackage(checkoutScript="evil", checkoutDigestScript="other digest")
+        s2 = CoreCheckoutStep(evilPkg, ("evil", "other digest", [], []),
             Env({"a" : "asdf", "q": "qwer" }), Env({ "a" : "asdf" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
     def testDigestFullEnv(self):
         """Full env does not change digest. It is only used for SCMs."""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             Env({"a" : "asdf", "q": "qwer" }), Env({ "a" : "asdf" }))
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             Env(), Env({ "a" : "asdf" }))
-        assert s1.getVariantId() == s2.getVariantId()
+        assert s1.variantId == s2.variantId
 
     def testDigestEnv(self):
         """Env changes digest"""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "asdf" }))
 
         # different value
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "qwer" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
         # added entry
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "asdf", "b" : "qwer" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
         # removed entry
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env())
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
     def testDigestEnvRotation(self):
         """Rotating characters between key-value pairs must be detected"""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "bc", "cd" : "e" }))
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "bcc", "d" : "e" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "bb", "c" : "dd", "e" : "ff" }))
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "bbc=dd", "e" : "ff" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
     def testDigestEmpyEnv(self):
         """Adding empty entry must be detected"""
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s1 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "b" }))
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
+        s2 = CoreCheckoutStep(nullPkg, ("script", "digest", [], []),
             digestEnv=Env({ "a" : "b", "" : "" }))
-        assert s1.getVariantId() != s2.getVariantId()
+        assert s1.variantId != s2.variantId
 
     def testDigestTools(self):
         """Tools must influence digest"""
+
         t1 = Empty()
-        t1.step = Empty()
-        t1.step.getVariantId = Mock(return_value=b'0123456789abcdef')
+        t1.coreStep = Empty()
+        t1.coreStep.variantId = b'0123456789abcdef'
+        t1.coreStep.isDeterministic = True
         t1.path = "p1"
         t1.libs = []
 
-        s1 = CheckoutStep()
-        s1.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
-            tools=Env({"a" : t1}))
+        p1 = MockCorePackage(tools={"a" : t1})
+        s1 = CoreCheckoutStep(p1, ("script", "digest", [], []))
 
         # tool name has no influence
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
-            tools=Env({"zz" : t1}))
-        assert s1.getVariantId() == s2.getVariantId()
+        p2 = MockCorePackage(tools={"zz" : t1})
+        s2 = CoreCheckoutStep(p2, ("script", "digest", [], []))
+        assert s1.variantId == s2.variantId
 
         # step digest change
         t2 = Empty()
-        t2.step = Empty()
-        t2.step.getVariantId = Mock(return_value=b'0123456789000000')
+        t2.coreStep = Empty()
+        t2.coreStep.variantId = b'0123456789000000'
+        t2.coreStep.isDeterministic = True
         t2.path = "p1"
         t2.libs = []
 
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
-            tools=Env({"a" : t2}))
-        assert s1.getVariantId() != s2.getVariantId()
+        p2 = MockCorePackage(tools={"a" : t2})
+        s2 = CoreCheckoutStep(p2, ("script", "digest", [], []))
+        assert s1.variantId != s2.variantId
 
         # path change
-        t2.step.getVariantId = Mock(return_value=b'0123456789abcdef')
+        t2.coreStep.variantId = b'0123456789abcdef'
         t2.path = "foo"
         t2.libs = []
 
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
-            tools=Env({"a" : t2}))
-        assert s1.getVariantId() != s2.getVariantId()
+        s2 = CoreCheckoutStep(p2, ("script", "digest", [], []))
+        assert s1.variantId != s2.variantId
 
         # libs change
-        t2.step.getVariantId = Mock(return_value=b'0123456789abcdef')
+        t2.coreStep.getVariantId = b'0123456789abcdef'
         t2.path = "p1"
         t2.libs = ["asdf"]
 
-        s2 = CheckoutStep()
-        s2.construct(nullPkg, nullFmt, None, ("script", "digest", [], []),
-            tools=Env({"a" : t2}))
-        assert s1.getVariantId() != s2.getVariantId()
+        s2 = CoreCheckoutStep(p2, ("script", "digest", [], []))
+        assert s1.variantId != s2.variantId
 

--- a/test/test_input_stringparser.py
+++ b/test/test_input_stringparser.py
@@ -175,15 +175,8 @@ class TestStringFunctions(TestCase):
     def testSandboxEnabled(self):
         with self.assertRaises(ParseError):
             funSandboxEnabled(["1", "2"], sandbox=None)
-        self.assertEqual(funSandboxEnabled([], sandbox=None), "false")
-
-        attrs = {'isEnabled.return_value' : False}
-        disabledSandbox = MagicMock(**attrs)
-        self.assertEqual(funSandboxEnabled([], sandbox=disabledSandbox), "false")
-
-        attrs = {'isEnabled.return_value' : True}
-        enabledSandbox = MagicMock(**attrs)
-        self.assertEqual(funSandboxEnabled([], sandbox=enabledSandbox), "true")
+        self.assertEqual(funSandboxEnabled([], sandbox=False), "false")
+        self.assertEqual(funSandboxEnabled([], sandbox=True), "true")
 
     def testToolDefined(self):
         with self.assertRaises(ParseError):

--- a/test/test_input_stringparser.py
+++ b/test/test_input_stringparser.py
@@ -179,8 +179,11 @@ class TestStringFunctions(TestCase):
         self.assertEqual(funSandboxEnabled([], sandbox=True), "true")
 
     def testToolDefined(self):
+        """deprecated is-tool-defined always returns false"""
+        attrs = {'getName.return_value' : "test"}
+        recipe = MagicMock(**attrs)
         with self.assertRaises(ParseError):
-            funToolDefined([], tools={})
-        self.assertEqual(funToolDefined(["a"], tools={"a":1, "b":2}), "true")
-        self.assertEqual(funToolDefined(["c"], tools={"a":1, "b":2}), "false")
+            funToolDefined([], recipe=recipe, tools={})
+        self.assertEqual(funToolDefined(["a"], recipe=recipe, tools={"a":1, "b":2}), "false")
+        self.assertEqual(funToolDefined(["c"], recipe=recipe, tools={"a":1, "b":2}), "false")
 


### PR DESCRIPTION
Get rid of as many intermediate objects as possible during package calculation. This gives quite a speed bonus and dramatically lowers the memory consumption.

@kolewu @ThomasFeher This breaks the plugin API by removing some (hopefully) unused parameters. Old plugins should still work as long as they do not use these parameters. They are filled with stub values if the plugin announces an old API version. It would be good to get your feedbach if this is a deal-breaker for you. 