### PR TITLE
add option to build dependencies only

### DIFF
--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2386,8 +2386,8 @@ class RecipeSet:
         {
             schema.Optional('destination') : str,
             schema.Optional('force') : bool,
-            schema.Optional('no_deps') : bool,
-            schema.Optional('build_mode') : schema.Or("build-only","normal", "checkout-only"),
+            schema.Optional('dep_mode') : schema.Or("no-deps", "all-packages", "deps-only"),
+            schema.Optional('build_mode') : schema.Or("build-only", "normal", "checkout-only"),
             schema.Optional('checkout_only') : bool,
             schema.Optional('clean') : bool,
             schema.Optional('verbosity') : int,

--- a/test/deps-only/recipes/app.yaml
+++ b/test/deps-only/recipes/app.yaml
@@ -1,0 +1,8 @@
+depends:
+    - lib
+
+buildScript: |
+    true # must not be exectued
+
+packageScript: |
+    true # must not be executed

--- a/test/deps-only/recipes/lib.yaml
+++ b/test/deps-only/recipes/lib.yaml
@@ -1,0 +1,5 @@
+buildScript: |
+    true # must not be exectued
+
+packageScript: |
+    true # must not be executed

--- a/test/deps-only/recipes/root.yaml
+++ b/test/deps-only/recipes/root.yaml
@@ -1,0 +1,10 @@
+root: True
+
+depends:
+    - app
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/deps-only/run.sh
+++ b/test/deps-only/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Test that --checkout-only does what it says. Additionally it checks that
+# tools that are used during a checkout step are still built.
+
+# checkout sources
+run_bob dev root --deps-only

--- a/test/no-deps/recipes/app.yaml
+++ b/test/no-deps/recipes/app.yaml
@@ -1,0 +1,8 @@
+depends:
+    - lib
+
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/no-deps/recipes/lib.yaml
+++ b/test/no-deps/recipes/lib.yaml
@@ -1,0 +1,5 @@
+buildScript: |
+    false # must not be exectued
+
+packageScript: |
+    false # must not be executed

--- a/test/no-deps/recipes/root.yaml
+++ b/test/no-deps/recipes/root.yaml
@@ -1,0 +1,10 @@
+root: True
+
+depends:
+    - app
+
+buildScript: |
+    true # must not be exectued
+
+packageScript: |
+    true # must not be executed

--- a/test/no-deps/run.sh
+++ b/test/no-deps/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Test that --checkout-only does what it says. Additionally it checks that
+# tools that are used during a checkout step are still built.
+
+# checkout sources
+run_bob dev root --no-deps


### PR DESCRIPTION
I have a use case where it's only necessary to build dependencies without the package itself. I tried to added the option, but I am not very pleased with the _checkDepsOnly function. Maybe you have an idea.