### PR TITLE
input: encode yaml with utf8

### DIFF
--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3111,7 +3111,7 @@ class YamlCache:
                     self.__files[name] = cached[0]
                     return pickle.loads(cached[1])
 
-            with open(name, "r") as f:
+            with open(name, "r", encoding='utf8') as f:
                 try:
                     rawData = f.read()
                     data = yaml.safe_load(rawData)


### PR DESCRIPTION
Without encoding=utf8 option recipes can only contain ascii characters. I think it should be possible to i.e. to add other characters to metaEnvironment and so on.