### PR TITLE
build: use start method "fork" on MSYS platforms

### DIFF
--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -125,7 +125,11 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         loop = asyncio.get_event_loop()
         origSigInt = signal.getsignal(signal.SIGINT)
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        multiprocessing.set_start_method('forkserver') # fork early before process gets big
+        # fork early before process gets big
+        if sys.platform == 'msys':
+            multiprocessing.set_start_method('fork')
+        else:
+            multiprocessing.set_start_method('forkserver')
         executor = concurrent.futures.ProcessPoolExecutor()
         executor.submit(dummy).result()
         signal.signal(signal.SIGINT, origSigInt)


### PR DESCRIPTION
instead of "forkserver", to start a new process.
Start method "forkserver" is only "available on Unix platforms, which
support passing file descriptors over Unix pipes" (see documentation of
"multiprocessing" module, section "Contexts and start methods"). This is
not the case for MSYS and leads to a "RuntimeError: received 0 items of
ancdata" in "/usr/lib/python3.7/multiprocessing/reduction.py", line 161,
in recvfds" for Python 3.7.