### PR TITLE
Extend "bob status" to check all unpushed commits of a Git repository

### DIFF
--- a/doc/manpages/bob-status.rst
+++ b/doc/manpages/bob-status.rst
@@ -118,10 +118,11 @@ Status codes can be interpreted as follows:
   :ref:`configuration-config-scmOverrides`. Pass ``--show-overrides`` to force
   the output of a ``STATUS`` line if the SCM is otherwise unmodified.
 - ``S`` = switched. The commit/tag/branch/URL is different from the recipe.
-- ``U`` = unpushed commmits. Git only. Some commits were made locally to the
-  configured branch but they have not yet been pushed to the remote.
-- ``u`` = unpushed branch(es). Git only. At least one branch exists with commits
-  that have not been pushed to a remote.
+- ``U`` = unpushed commits on configured branch. Git only. Some commits were made
+  locally to the configured branch but they have not yet been pushed to the remote.
+- ``u`` = unpushed commits not on configured branch. Git only. There are commits
+  on other local branches than the configured branch, on a possibly detached HEAD
+  or in the stash that have not been pushed to a remote.
 
 The command shows the status of the current checkout. If the recipe was changed and
 the next build would move a checkout to the attic then the current information still

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -313,16 +313,17 @@ class GitScm(Scm):
                 status.add(ScmTaint.modified, joinLines("> modified:",
                     indent(output, '   ')))
 
-            # The following shows unpushed commits on all local branches.
+            # The following shows all unpushed commits reachable by any ref
+            # (local branches, stash, detached HEAD, etc).
             # Exclude HEAD if the configured branch is checked out to not
             # double-count them. Does not mark the SCM as dirty.
-            what = ['--branches', '--not', '--remotes']
+            what = ['--all', '--not', '--remotes']
             if onCorrectBranch: what.append('HEAD')
             output = self.callGit(workspacePath, 'log', '--oneline', '--decorate',
                 *what)
             if output:
                 status.add(ScmTaint.unpushed_local,
-                    joinLines("> unpushed banches:", indent(output, '   ')))
+                    joinLines("> unpushed commits:", indent(output, '   ')))
 
         except BuildError as e:
             status.add(ScmTaint.error, e.slogan)

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -304,7 +304,8 @@ class GitScm(Scm):
                         'refs/remotes/origin/'+self.__branch+'..HEAD')
                     if output:
                         status.add(ScmTaint.unpushed_main,
-                            joinLines("> unpushed commits:", indent(output, '   ')))
+                            joinLines("> unpushed commits on {}:".format(self.__branch),
+                                indent(output, '   ')))
                     onCorrectBranch = True
 
             # Check for modifications wrt. checked out commit
@@ -323,7 +324,7 @@ class GitScm(Scm):
                 *what)
             if output:
                 status.add(ScmTaint.unpushed_local,
-                    joinLines("> unpushed commits:", indent(output, '   ')))
+                    joinLines("> unpushed local commits:", indent(output, '   ')))
 
         except BuildError as e:
             status.add(ScmTaint.error, e.slogan)


### PR DESCRIPTION
We propose to extend the behavior of `bob status` for Git repositories. We'd like to see not only unpushed commits on local branches but also from stash or the possibly detached HEAD for instance.