### PR TITLE
Allow local files with the "url" SCM.

### DIFF
--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2517,6 +2517,7 @@ class RecipeSet:
                 schema.Optional('sandboxInvariant') : bool,
                 schema.Optional('uniqueDependency') : bool,
                 schema.Optional('mergeEnvironment') : bool,
+                schema.Optional('secureSSL') : bool,
             },
             error="Invalid policy specified! Maybe your Bob is too old?"
         )

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -88,7 +88,17 @@ class UrlScm(Scm):
     def asScript(self):
         options = "-sSgLf"
         if not self.__sslVerify: options += "k"
-        ret = """
+        ret = ""
+        if self.__url[0] == '/':
+            # Local files: copy only if newer (u), target never is a directory (T)
+            tpl = """
+{HEADER}
+mkdir -p {DIR}
+cd {DIR}
+cp -uT {URL} {FILE}
+"""
+        else:
+            tpl = """
 {HEADER}
 mkdir -p {DIR}
 cd {DIR}
@@ -103,7 +113,8 @@ else
         mv $F {FILE}
     )
 fi
-""".format(HEADER=super().asScript(), DIR=quote(self.__dir), URL=quote(self.__url),
+"""
+        ret = tpl.format(HEADER=super().asScript(), DIR=quote(self.__dir), URL=quote(self.__url),
            FILE=quote(self.__fn), OPTIONS=options)
 
         if self.__digestSha1:

--- a/test/url-scm-file/file.txt
+++ b/test/url-scm-file/file.txt
@@ -1,0 +1,1 @@
+This is a file.

--- a/test/url-scm-file/recipes/root.yaml
+++ b/test/url-scm-file/recipes/root.yaml
@@ -1,0 +1,9 @@
+root: true
+
+checkoutSCM:
+  - scm: url
+    url: ${URL}
+
+buildScript: cp $1/* .
+
+packageScript: cp $1/* .

--- a/test/url-scm-file/run.sh
+++ b/test/url-scm-file/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#
+#  Litmus test for "url" SCM with files.
+#  Verify that a file name in place of an URL works.
+#
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Source file. If shell didn't give us an absolute file name, bail out early.
+file="$PWD/file.txt"
+test "${file:0:1}" = "/"
+
+# Build and fetch result path
+run_bob dev -DURL="$file" root
+path=$(run_bob query-path -DURL="$file" -f {dist} root)
+test -n "$path"
+
+# Build result must contain a copy of the file.
+diff -q "$path/file.txt" "$file"


### PR DESCRIPTION
If the URL starts with '/', it is treated as a local file and is just copied
with 'cp' instead of downloaded using 'curl'.  This makes it possible to
easily build from tarballs in a sandbox that has no network access and no
'curl' command.