### PR TITLE
Fix status of unpushed tags

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -299,7 +299,7 @@ class GitScm(Scm):
                 if self.__tag not in output:
                     actual = ("'" + ", ".join(output) + "'") if output else "not on any tag"
                     status.add(ScmTaint.switched,
-                        "> tag: configured: '{}', actual: '{}'".format(self.__tag, actual))
+                        "> tag: configured: '{}', actual: {}".format(self.__tag, actual))
 
                 # Need to check if the tag still exists. Otherwise the "git
                 # log" command at the end will trip.


### PR DESCRIPTION
Currently all tags that are not on a remote branch are flagged as unpushed commit. This is typically not true and almost always a false positive. Remove tags completely from the game because git does not know anyway which remote has what tags.