### PR TITLE
WIP: archive: added JFrog Artifactory backend

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1515,6 +1515,12 @@ the following table for supported backends and their configuration.
 Backend     Description
 =========== ===================================================================
 none        Do not use a binary repository (default).
+artifactory JFrog Artifactory backend. Use the ``url`` keyword to provide the
+            repository url. Use optional keys ``username`` to specify the user
+            and ``key`` for the API-key or password. Without ``username`` and
+            ``key`` either no authentication or the global artifactory
+            configuration file is used. See dohq-artifactory documentation for
+            details.
 azure       Microsoft Azure Blob storage backend. The account must be specified
             in the ``account`` key. Either a ``key`` or a ``sasToken`` may
             be set to authenticate, otherwise an anonymous access is used.
@@ -1535,8 +1541,8 @@ shell       This backend can be used to execute commands that do the actual up-
             example below for a possible use with ``scp``.
 =========== ===================================================================
 
-The directory layouts of the ``azure``, ``file``, ``http`` and ``shell``
-(``$BOB_REMOTE_ARTIFACT``) backends are compatible. If multiple download
+The directory layouts of the ``artifactory``, ``azure``, ``file``, ``http`` and
+``shell`` (``$BOB_REMOTE_ARTIFACT``) backends are compatible. If multiple download
 backends are available they will be tried in order until a matching artifact is
 found. All available upload backends are used for uploading artifacts. Any
 failing upload will fail the whole build.

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2555,6 +2555,7 @@ class ArchiveValidator:
         artifactoryArchive.update({
             'url' : str,
             schema.Optional('key') : str,
+            schema.Optional('properties') : schema.Schema({ schema.Regex(r'^[A-Za-z_][A-Za-z0-9_]*$') : str }),
             schema.Optional('username') : str,
         })
         self.__backends = {

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2526,7 +2526,8 @@ class PackageMatcher:
 
 class ArchiveValidator:
     def __init__(self):
-        self.__validTypes = schema.Schema({'backend': schema.Or('none', 'file', 'http', 'shell', 'azure')},
+        self.__validTypes = schema.Schema({'backend': schema.Or('none',
+            'file', 'http', 'shell', 'azure', 'artifactory')},
             ignore_extra_keys=True)
         baseArchive = {
             'backend' : str,
@@ -2550,12 +2551,19 @@ class ArchiveValidator:
             schema.Optional('key') : str,
             schema.Optional('sasToken"') : str,
         })
+        artifactoryArchive = baseArchive.copy()
+        artifactoryArchive.update({
+            'url' : str,
+            schema.Optional('key') : str,
+            schema.Optional('username') : str,
+        })
         self.__backends = {
             'none' : schema.Schema(baseArchive),
             'file' : schema.Schema(fileArchive),
             'http' : schema.Schema(httpArchive),
             'shell' : schema.Schema(shellArchive),
             'azure' : schema.Schema(azureArchive),
+            'artifactory' : schema.Schema(artifactoryArchive),
         }
 
     def validate(self, data):


### PR DESCRIPTION
The JFrog artifactory backend uses the dohq-artifcatory python lib and supports the
authentication methods (username+password, API-Key, global configuration file) provided
by this library.