### PR TITLE
ADD qtcreator support for windows by MSYS2

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -112,6 +112,9 @@ QtCreator project generator
                            [--exclude Excludes] [--include Includes] [--kit KIT]
                            [-S START_INCLUDES] [-C CONFIG_DEF]
 
+This generator also supports generation of project files for native Windows QtCreator 
+by using MSYS2. The prerequisite is, that MSYS2 must be started by msys2_shell.cmd script.
+
 The QtCreator project generator has the following specific options. They have
 to be passed on the command line *after* the package name.
 


### PR DESCRIPTION
update of MR: https://github.com/BobBuildTool/bob/pull/235 

- I got no better solution that using pwd -W msys2 tool for getting the cwd/pwd in windows style.
- It is imported to start msys2 by "msys2_shell.cmd" to get WD environment-vaiable. I got no better solution to get install path of msys2 to execute bob by qt-creator.
- Replace "::" is important in some case, because of "C:/" shall not match and replaced to "C_/".

TODO

- finally there is one issue remaining: inside the qt-creator the project-explorer shows all directories starting at root point (e.g. "C:"), because of the source files not inside the directory of the project files. I have no idea how to solve this. (in linux it is solved by symlinks.)