### PR TITLE
input: git: add timeout option for Jenkins

### DIFF
--- a/contrib/bash-completion
+++ b/contrib/bash-completion
@@ -173,7 +173,7 @@ __bob_jenkins_add()
                __bob_complete_path
                ;;
             -o)
-               __bob_complete_words "artifacts.copy jobs.isolate jobs.policy scm.git.shallow scm.ignore-hooks scm.poll shared.dir" "" "="
+               __bob_complete_words "artifacts.copy jobs.isolate jobs.policy scm.git.shallow scm.git.timeout scm.ignore-hooks scm.poll shared.dir" "" "="
                ;;
          esac
    esac
@@ -282,7 +282,7 @@ __bob_jenkins_set_options()
                COMPREPLY=( )
                ;;
             -o)
-               __bob_complete_words "artifacts.copy jobs.isolate scm.git.shallow scm.ignore-hooks scm.poll shared.dir" "" "="
+               __bob_complete_words "artifacts.copy jobs.isolate scm.git.shallow scm.git.timeout scm.ignore-hooks scm.poll shared.dir" "" "="
                ;;
             *)
                __bob_complete_words "$($bob --color=never jenkins ls 2>/dev/null)"

--- a/doc/manpages/bob-jenkins.rst
+++ b/doc/manpages/bob-jenkins.rst
@@ -259,6 +259,10 @@ scm.git.shallow
        change log. Jenkins will not be able to find the reference commit of
        the last run if the branch advanced by more commits than were cloned.
 
+scm.git.timeout
+    Instruct the Jenkins git plugin to use the given timeout (minutes) for clone 
+    and fetch operations.
+
 scm.ignore-hooks
     Boolean option (possible values: '0' or 'false' resp. '1' or 'true') to set
     the "Ignore post-commit hooks" option on all jobs. This instructs Jenkins

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -226,21 +226,34 @@ class GitScm(Scm):
             "hudson.plugins.git.extensions.impl.CleanCheckout")
         ElementTree.SubElement(extensions,
             "hudson.plugins.git.extensions.impl.PruneStaleBranch")
+        # set git clone options
         shallow = options.get("scm.git.shallow")
-        if shallow is not None:
-            try:
-                shallow = int(shallow)
-                if shallow < 0: raise ValueError()
-            except ValueError:
-                raise BuildError("Invalid 'git.shallow' option: " + str(shallow))
-            if shallow > 0:
-                co = ElementTree.SubElement(extensions,
+        timeout = options.get("scm.git.timeout")
+        if shallow is not None or timeout is not None:
+            co = ElementTree.SubElement(extensions,
                     "hudson.plugins.git.extensions.impl.CloneOption")
-                ElementTree.SubElement(co, "shallow").text = "true"
-                ElementTree.SubElement(co, "noTags").text = "false"
-                ElementTree.SubElement(co, "reference").text = ""
-                ElementTree.SubElement(co, "depth").text = str(shallow)
-                ElementTree.SubElement(co, "honorRefspec").text = "false"
+            if shallow is not None:
+                try:
+                    shallow = int(shallow)
+                    if shallow < 0: raise ValueError()
+                except ValueError:
+                    raise BuildError("Invalid 'git.shallow' option: " + str(shallow))
+                if shallow > 0:
+                    ElementTree.SubElement(co, "shallow").text = "true"
+                    ElementTree.SubElement(co, "noTags").text = "false"
+                    ElementTree.SubElement(co, "reference").text = ""
+                    ElementTree.SubElement(co, "depth").text = str(shallow)
+                    ElementTree.SubElement(co, "honorRefspec").text = "false"
+
+            if timeout is not None:
+                try:
+                    timeout = int(timeout)
+                    if timeout < 0: raise ValueError()
+                except ValueError:
+                    raise BuildError("Invalid 'git.timeout' option: " + str(shallow))
+                if timeout > 0:
+                    ElementTree.SubElement(co, "timeout").text = str(timeout)
+
         if isTrue(options.get("scm.ignore-hooks", "0")):
             ElementTree.SubElement(extensions,
                 "hudson.plugins.git.extensions.impl.IgnoreNotifyCommit")

--- a/test/test_jenkins_set_options.py
+++ b/test/test_jenkins_set_options.py
@@ -178,6 +178,23 @@ archive:
             self.executeBobJenkinsCmd("push -q myTestJenkins")
         assert(type(c.exception) == BuildError)
 
+    def testSetGitTimeoutClone(self):
+        self.executeBobJenkinsCmd("set-options -o scm.git.timeout=42 myTestJenkins")
+        self.executeBobJenkinsCmd("push -q myTestJenkins")
+        send = self.jenkinsMock.getServerData()
+        config = ElementTree.fromstring(send[0][1])
+        for clone in config.iter('hudson.plugins.git.extensions.impl.CloneOption'):
+            found = 0
+            for a in clone.getiterator():
+                if a.tag == 'timeout':
+                    assert(a.text == '42')
+                    found += 1
+            assert(found == 1)
+        self.executeBobJenkinsCmd("set-options -o scm.git.timeout=-10 myTestJenkins")
+        with self.assertRaises(Exception) as c:
+            self.executeBobJenkinsCmd("push -q myTestJenkins")
+        assert(type(c.exception) == BuildError)
+
     def testSetPrefix(self):
         self.executeBobJenkinsCmd("set-options -p abcde- myTestJenkins")
         self.executeBobJenkinsCmd("push -q myTestJenkins")


### PR DESCRIPTION
By default Jenkins has a timeout of 10 minutes for git clone and fetch
operations, sometimes this is not enough. With the setting the
"scm.git.timeout" it is possible to change the timeout.