### PR TITLE
Don't fetch Git commits explicitly

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -138,9 +138,7 @@ class GitScm(Scm):
 
         if self.__tag or self.__commit:
             refSpec = "'+refs/heads/*:refs/remotes/origin/*' "
-            if self.__commit:
-                refSpec += self.__commit
-            else:
+            if self.__tag:
                 refSpec += quote("refs/tags/{0}:refs/tags/{0}".format(self.__tag))
             return dedent("""\
                 {HEADER}


### PR DESCRIPTION
In pull request #236 checkout script for Git was extended to fetch tags explicitly (see c0034f8). Additionally also commits are now fetched explicitly.

But fetching commits explicitly may not be supported by git servers and can be denied, e.g. as follows:

```
error: Server does not allow request for unadvertised object
```

Since we have recipes, which reference specific commits, we suggest to change the behavior of the checkout script to not fetch commits explicitly.

Typically commits, which should be checked out are reachable by an existing branch and doesn't need to be fetched explicitly. Are there any use cases, where a commit should be checked out, which is not reachable by any branch, e.g. by a tag only which is not on a branch?

Otherwise the server configuration has to be changed, e.g. by option `uploadpack.allowAnySHA1InWant` (see [git-fetch-pack](https://git-scm.com/docs/git-fetch-pack))