### PR TITLE
.update added string substitution for archive url

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -450,7 +450,7 @@ class LocalArchiveUploader:
 class SimpleHttpArchive(BaseArchive):
     def __init__(self, spec, secureSSL):
         super().__init__(spec)
-        self.__url = urllib.parse.urlparse(Env().substitute(spec["url"], ""))
+        self.__url = urllib.parse.urlparse(Env(os.environ).substitute(spec["url"], ""))
         self.__connection = None
         self.__sslVerify = spec.get("sslVerify", secureSSL)
 

--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -19,6 +19,7 @@ it must not be overwritten. The backend should make sure that even on
 concurrent uploads the artifact must appear atomically for unrelated readers.
 """
 
+from .stringparser import Env
 from .errors import BuildError
 from .tty import stepAction, SKIPPED, EXECUTED, WARNING, INFO, TRACE, ERROR
 from .utils import asHexStr, removePath, isWindows
@@ -449,7 +450,7 @@ class LocalArchiveUploader:
 class SimpleHttpArchive(BaseArchive):
     def __init__(self, spec, secureSSL):
         super().__init__(spec)
-        self.__url = urllib.parse.urlparse(spec["url"])
+        self.__url = urllib.parse.urlparse(Env().substitute(spec["url"], ""))
         self.__connection = None
         self.__sslVerify = spec.get("sslVerify", secureSSL)
 


### PR DESCRIPTION
Hey there,

i analyzed a strange behavior in bob.

in Msys2:
```
$ bob dev windows/fdt::phpsit::all-dev/fdt::phpsit::coreonly-dev/lib::boost-dev/ --download forced -vv
>> windows/fdt::phpsit::all-dev/fdt::phpsit::coreonly-dev/lib::boost-dev
   MAP-SRC   http://artifact-build-c01.fdtech.intern/d1/82/adda254067ad26e15dcccb939558aa3e86de-1.buildid .. ok
   DOWNLOAD  dev/dist/lib/boost-dev/2/workspace  from http://artifact-build-c01.fdtech.intern/0f/50/d7c84c4732de3b6480c1e1887c191a4c1a82-1.tgz .. ok
Jenkins Msys2:
+ BOB_UPLOAD_BID=d182adda254067ad26e15dcccb939558aa3e86de-1
+ BOB_DOWNLOAD_BID=0f50d7c84c4732de3b6480c1e1887c191a4c1a82-1
```
 
in Wsl (Windows Subsysstem Linux - Ubuntu 18):
```
bob dev linux/fdt::phpsit::all-dev/fdt::phpsit::coreonly-dev/lib::boost-dev/ --download forced -vv
>> linux/fdt::phpsit::all-dev/fdt::phpsit::coreonly-dev/lib::boost-dev
   MAP-SRC   http://artifact-build-c01.fdtech.intern/d1/82/adda254067ad26e15dcccb939558aa3e86de-1.buildid .. ok
   DOWNLOAD  dev/dist/lib/boost-dev/1/workspace  from http://artifact-build-c01.fdtech.intern/38/bb/2dd99c3c65bba81b9bca7dcf95c48dd49cf3-1.tgz .. not found
Jenkins linux:
+ BOB_UPLOAD_BID=d182adda254067ad26e15dcccb939558aa3e86de-1
+ BOB_DOWNLOAD_BID=cd11e04aba3a969b040462e347d1207d0ebf107e-1
```

Interesting: 
* The build-id for linux and windows is the same.
* depending which system was build last, the correct artifacts can be downloaded, the second system failed everytime.

My idea to fix this ?temporary? is to split windows and linux location to the artifacts.

so I changed the default.yaml to this:
```
archive:
    backend: http
    url: http://artifact-build-c01.fdtech.intern/${OS:-Linux}
```
 
This is working pretty well on jenkins servers. All artifacts will be located correctly.
 
But bob is failing localy when he creates the download url - there is no string substitution available.
 
MAP-SRC   http://artifact-build-c01.fdtech.intern/${OS:-Linux}/63/d6/94ba8876657a0783276c1972585ba5769905-1.buildid .. not found
 
But this I have ?fixed? / worked around by this merge request :)