### PR TITLE
Fix artifact sharing

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -369,7 +369,7 @@ class LocalArchive(BaseArchive):
             # upload artifact
             cd $WORKSPACE
             BOB_UPLOAD_BID="$(hexdump -ve '/1 "%02x"' {BUILDID}){GEN}"
-            BOB_UPLOAD_FILE="{DIR}/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
+            BOB_UPLOAD_FILE={DIR}"/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
             if [[ ! -e ${{BOB_UPLOAD_FILE}} ]] ; then
                 (
                     set -eE
@@ -381,7 +381,7 @@ class LocalArchive(BaseArchive):
                         [[ -r "$BOB_UPLOAD_FILE" ]] || exit 2
                     fi
                 ){FIXUP}
-            fi""".format(DIR=self.__basePath, BUILDID=quote(buildIdFile), RESULT=quote(resultFile),
+            fi""".format(DIR=quote(self.__basePath), BUILDID=quote(buildIdFile), RESULT=quote(resultFile),
                          FIXUP=" || echo Upload failed: $?" if self._ignoreErrors() else "",
                          GEN=ARCHIVE_GENERATION, SUFFIX=suffix))
 
@@ -395,10 +395,10 @@ class LocalArchive(BaseArchive):
         return "\n" + textwrap.dedent("""\
             if [[ ! -e {RESULT} ]] ; then
                 BOB_DOWNLOAD_BID="$(hexdump -ve '/1 "%02x"' {BUILDID}){GEN}"
-                BOB_DOWNLOAD_FILE="{DIR}/${{BOB_DOWNLOAD_BID:0:2}}/${{BOB_DOWNLOAD_BID:2:2}}/${{BOB_DOWNLOAD_BID:4}}{SUFFIX}"
+                BOB_DOWNLOAD_FILE={DIR}"/${{BOB_DOWNLOAD_BID:0:2}}/${{BOB_DOWNLOAD_BID:2:2}}/${{BOB_DOWNLOAD_BID:4}}{SUFFIX}"
                 cp "$BOB_DOWNLOAD_FILE" {RESULT} || echo Download failed: $?
             fi
-            """.format(DIR=self.__basePath, BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
+            """.format(DIR=quote(self.__basePath), BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
                        GEN=ARCHIVE_GENERATION, SUFFIX=ARTIFACT_SUFFIX))
 
     def uploadJenkinsLiveBuildId(self, step, liveBuildId, buildId):
@@ -574,13 +574,13 @@ class SimpleHttpArchive(BaseArchive):
             # upload artifact
             cd $WORKSPACE
             BOB_UPLOAD_BID="$(hexdump -ve '/1 "%02x"' {BUILDID}){GEN}"
-            BOB_UPLOAD_URL="{URL}/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
+            BOB_UPLOAD_URL={URL}"/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
             if ! curl --output /dev/null --silent --head --fail {INSECURE} "$BOB_UPLOAD_URL" ; then
                 BOB_UPLOAD_RSP=$(curl -sSgf {INSECURE} -w '%{{http_code}}' -H 'If-None-Match: *' -T {RESULT} "$BOB_UPLOAD_URL" || true)
                 if [[ $BOB_UPLOAD_RSP != 2?? && $BOB_UPLOAD_RSP != 412 ]]; then
                     echo "Upload failed with code $BOB_UPLOAD_RSP"{FAIL}
                 fi
-            fi""".format(URL=self.__url.geturl(), BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
+            fi""".format(URL=quote(self.__url.geturl()), BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
                          FAIL="" if self._ignoreErrors() else "; exit 1",
                          GEN=ARCHIVE_GENERATION, SUFFIX=ARTIFACT_SUFFIX,
                          INSECURE=insecure))
@@ -594,10 +594,10 @@ class SimpleHttpArchive(BaseArchive):
         return "\n" + textwrap.dedent("""\
             if [[ ! -e {RESULT} ]] ; then
                 BOB_DOWNLOAD_BID="$(hexdump -ve '/1 "%02x"' {BUILDID}){GEN}"
-                BOB_DOWNLOAD_URL="{URL}/${{BOB_DOWNLOAD_BID:0:2}}/${{BOB_DOWNLOAD_BID:2:2}}/${{BOB_DOWNLOAD_BID:4}}{SUFFIX}"
+                BOB_DOWNLOAD_URL={URL}"/${{BOB_DOWNLOAD_BID:0:2}}/${{BOB_DOWNLOAD_BID:2:2}}/${{BOB_DOWNLOAD_BID:4}}{SUFFIX}"
                 curl -sSg {INSECURE} --fail -o {RESULT} "$BOB_DOWNLOAD_URL" || echo Download failed: $?
             fi
-            """.format(URL=self.__url.geturl(), BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
+            """.format(URL=quote(self.__url.geturl()), BUILDID=quote(buildIdFile), RESULT=quote(tgzFile),
                        GEN=ARCHIVE_GENERATION, SUFFIX=ARTIFACT_SUFFIX,
                        INSECURE=insecure))
 
@@ -612,12 +612,12 @@ class SimpleHttpArchive(BaseArchive):
             # upload live build-id
             cd $WORKSPACE
             BOB_UPLOAD_BID="$(hexdump -ve '/1 "%02x"' {LIVEBUILDID}){GEN}"
-            BOB_UPLOAD_URL="{URL}/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
+            BOB_UPLOAD_URL={URL}"/${{BOB_UPLOAD_BID:0:2}}/${{BOB_UPLOAD_BID:2:2}}/${{BOB_UPLOAD_BID:4}}{SUFFIX}"
             BOB_UPLOAD_RSP=$(curl -sSgf {INSECURE} -w '%{{http_code}}' -H 'If-None-Match: *' -T {BUILDID} "$BOB_UPLOAD_URL" || true)
             if [[ $BOB_UPLOAD_RSP != 2?? && $BOB_UPLOAD_RSP != 412 ]]; then
                 echo "Upload failed with code $BOB_UPLOAD_RSP"{FAIL}
             fi
-            """.format(URL=self.__url.geturl(), LIVEBUILDID=quote(liveBuildId),
+            """.format(URL=quote(self.__url.geturl()), LIVEBUILDID=quote(liveBuildId),
                        BUILDID=quote(buildId),
                        FAIL="" if self._ignoreErrors() else "; exit 1",
                        GEN=ARCHIVE_GENERATION, SUFFIX=BUILDID_SUFFIX,
@@ -848,8 +848,8 @@ class AzureArchive(BaseArchive):
             # upload artifact
             cd $WORKSPACE
             bob _upload azure {ARGS} {ACCOUNT} {CONTAINER} {BUILDID} {SUFFIX} {RESULT}{FIXUP}
-            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=self.__account,
-                       CONTAINER=self.__container, BUILDID=quote(buildIdFile),
+            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=quote(self.__account),
+                       CONTAINER=quote(self.__container), BUILDID=quote(buildIdFile),
                        RESULT=quote(tgzFile),
                        FIXUP=" || echo Upload failed: $?" if self._ignoreErrors() else "",
                        SUFFIX=ARTIFACT_SUFFIX))
@@ -866,7 +866,7 @@ class AzureArchive(BaseArchive):
             if [[ ! -e {RESULT} ]] ; then
                 bob _download azure {ARGS} {ACCOUNT} {CONTAINER} {BUILDID} {SUFFIX} {RESULT} || echo Download failed: $?
             fi
-            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=self.__account,
+            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=quote(self.__account),
                        CONTAINER=self.__container, BUILDID=quote(buildIdFile),
                        RESULT=quote(tgzFile), SUFFIX=ARTIFACT_SUFFIX))
 
@@ -882,8 +882,8 @@ class AzureArchive(BaseArchive):
             # upload live build-id
             cd $WORKSPACE
             bob _upload azure {ARGS} {ACCOUNT} {CONTAINER} {LIVEBUILDID} {SUFFIX} {BUILDID}{FIXUP}
-            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=self.__account,
-                       CONTAINER=self.__container, LIVEBUILDID=quote(liveBuildId),
+            """.format(ARGS=" ".join(map(quote, args)), ACCOUNT=quote(self.__account),
+                       CONTAINER=quote(self.__container), LIVEBUILDID=quote(liveBuildId),
                        BUILDID=quote(buildId),
                        FIXUP=" || echo Upload failed: $?" if self._ignoreErrors() else "",
                        SUFFIX=BUILDID_SUFFIX))

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -473,7 +473,7 @@ class JenkinsJob:
         ret.append(line)
         return "\n".join(ret)
 
-    def dumpStepLiveBuildIdGen(self, step):
+    def dumpStepLiveBuildIdGen(self, step, isWin):
         # This makes only sense if we can upload the result. OTOH the live
         # build-id file acts as an indicator of a first-time/clean checkout. We
         # have to still create it so that we don't accidentally upload rogue
@@ -488,7 +488,7 @@ class JenkinsJob:
             buildId = JenkinsJob._buildIdName(step)
             ret = [ "bob-hash-engine --state .state -o {} <<'EOF'".format(liveBuildId),
                     spec, "EOF" ]
-            ret.append(self.__archive.uploadJenkinsLiveBuildId(step, liveBuildId, buildId))
+            ret.append(self.__archive.uploadJenkinsLiveBuildId(step, liveBuildId, buildId, isWin))
 
         # Without sandbox we only upload the live build-id on the initial
         # checkout. Otherwise accidental modifications of the sources can
@@ -885,7 +885,7 @@ class JenkinsJob:
         for d in sorted(self.__checkoutSteps.values()):
             ensureFingerprint(d)
             buildIdCalc.extend(self.dumpStepBuildIdGen(d))
-            buildIdCalc.extend(self.dumpStepLiveBuildIdGen(d))
+            buildIdCalc.extend(self.dumpStepLiveBuildIdGen(d, windows))
         for d in sorted(self.__buildSteps.values()):
             ensureFingerprint(d)
             buildIdCalc.extend(self.dumpStepBuildIdGen(d))

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -413,7 +413,7 @@ class BaseTester:
             self.__testArtifact(bid)
 
             # upload live build-id
-            script = archive.uploadJenkinsLiveBuildId(None, "test.buildid", "test.buildid")
+            script = archive.uploadJenkinsLiveBuildId(None, "test.buildid", "test.buildid", False)
             callJenkinsScript(script, tmp)
 
             # test that live-build-id is uploaded
@@ -426,7 +426,7 @@ class BaseTester:
                 script = archive.upload(DummyStep(), "error.buildid", "result.tgz")
                 callJenkinsScript(script, tmp)
             with self.assertRaises(subprocess.CalledProcessError):
-                script = archive.uploadJenkinsLiveBuildId(None, "error.buildid", "test.buildid")
+                script = archive.uploadJenkinsLiveBuildId(None, "error.buildid", "test.buildid", False)
                 callJenkinsScript(script, tmp)
 
     def testUploadJenkinsNoFail(self):
@@ -443,7 +443,7 @@ class BaseTester:
             # these uploads must not fail even though they do not succeed
             script = archive.upload(DummyStep(), "error.buildid", "result.tgz")
             callJenkinsScript(script, tmp)
-            script = archive.uploadJenkinsLiveBuildId(None, "error.buildid", "test.buildid")
+            script = archive.uploadJenkinsLiveBuildId(None, "error.buildid", "test.buildid", False)
             callJenkinsScript(script, tmp)
 
     def testDisabled(self):
@@ -454,7 +454,7 @@ class BaseTester:
         self.assertEqual(archive.download(DummyStep(), "unused", "unused"), "")
 
         self.assertEqual(archive.upload(DummyStep(), "unused", "unused"), "")
-        self.assertEqual(archive.uploadJenkinsLiveBuildId(DummyStep(), "unused", "unused"), "")
+        self.assertEqual(archive.uploadJenkinsLiveBuildId(DummyStep(), "unused", "unused", False), "")
 
         run(archive.downloadPackage(DummyStep(), b'\x00'*20, "unused", "unused"))
         self.assertEqual(run(archive.downloadLocalLiveBuildId(DummyStep(), b'\x00'*20)), None)
@@ -485,7 +485,7 @@ class TestDummyArchive(TestCase):
     def testUploadJenkins(self):
         ret = DummyArchive().upload(b'\x00'*20, "unused", "unused")
         self.assertEqual(ret, "")
-        ret = DummyArchive().uploadJenkinsLiveBuildId(None, "unused", "unused")
+        ret = DummyArchive().uploadJenkinsLiveBuildId(None, "unused", "unused", False)
         self.assertEqual(ret, "")
 
     def testUploadLocal(self):

--- a/test/test_jenkins_set_options.py
+++ b/test/test_jenkins_set_options.py
@@ -136,15 +136,15 @@ archive:
         self.executeBobJenkinsCmd("set-options --download myTestJenkins")
         self.executeBobJenkinsCmd("push -q myTestJenkins")
         send = self.jenkinsMock.getServerData()
-        assert('BOB_DOWNLOAD_URL="http://localhost:8001/upload/' in send[0][1].decode('utf-8'))
+        assert('BOB_DOWNLOAD_URL=http://localhost:8001/upload' in send[0][1].decode('utf-8'))
         self.executeBobJenkinsCmd("set-options --reset --add-root test myTestJenkins")
         self.executeBobJenkinsCmd("push -q myTestJenkins")
         send = self.jenkinsMock.getServerData()
-        assert('BOB_DOWNLOAD_URL="http://localhost:8001/upload/' not in send[0][1].decode('utf-8'))
+        assert('BOB_DOWNLOAD_URL=http://localhost:8001/upload' not in send[0][1].decode('utf-8'))
         self.executeBobJenkinsCmd("set-options --upload myTestJenkins")
         self.executeBobJenkinsCmd("push -q myTestJenkins")
         send = self.jenkinsMock.getServerData()
-        assert('BOB_UPLOAD_URL="http://localhost:8001/upload/' in send[0][1].decode('utf-8'))
+        assert('BOB_UPLOAD_URL=http://localhost:8001/upload' in send[0][1].decode('utf-8'))
 
     def testSetURL(self):
         self.newJenkinsMock = JenkinsMock()


### PR DESCRIPTION
Let's treat Windows and POSIX systems differently w.r.t. live build-ids. This should prevent artifact sharing problems when the same repository is used for Windows and Linux builds.

Contraty to #263 this is done automatically. It also fixes the unintended shell interpretation of URLs.