### PR TITLE
builder/project: add packages download option

### DIFF
--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -48,7 +48,7 @@ Options
     built package(s).
 
 ``--download MODE``
-    Download from binary archive (yes, no, deps, forced, forced-deps)
+    Download from binary archive (yes, no, deps, forced, forced-deps, packages)
 
     no
       build given module and it's dependencies from sources
@@ -66,6 +66,8 @@ Options
     forced-fallback
       combination of forced and forced-deps modes: if forced fails fall back to
       forced-deps
+    packages=<packages regex>
+      download modules that match a given regular expression, build all other.
 
 ``--incremental``
     Reuse build directory for incremental builds.

--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -31,7 +31,7 @@ Options
     Use config File
 
 ``--download MODE``
-    Download from binary archive (yes, no, deps, forced, forced-deps)
+    Download from binary archive (yes, no, deps, packages)
 
     See :ref:`bob-dev(1) <manpage-dev>` for details.
 

--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -38,6 +38,11 @@ def runHook(recipes, hook, args):
     return ret
 
 def commonBuildDevelop(parser, argv, bobRoot, develop):
+    def _downloadArgument(arg):
+        if arg.startswith('packages=') or arg in ['yes', 'no', 'deps', 'forced', 'forced-deps', 'forced-fallback']:
+            return arg
+        raise argparse.ArgumentTypeError("{} invalid.".format(arg))
+
     parser.add_argument('packages', metavar='PACKAGE', type=str, nargs='+',
         help="(Sub-)package to build")
     parser.add_argument('--destination', metavar="DEST", default=None,
@@ -94,8 +99,8 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
     parser.add_argument('--no-link-deps', default=None, help="Do not add linked dependencies to workspace paths",
         dest='link_deps', action='store_false')
     parser.add_argument('--download', metavar="MODE", default=None,
-        help="Download from binary archive (yes, no, deps, forced, forced-deps, forced-fallback)",
-        choices=['yes', 'no', 'deps', 'forced', 'forced-deps', 'forced-fallback'])
+        help="Download from binary archive (yes, no, deps, forced, forced-deps, forced-fallback, packages=<packages>",
+        type=_downloadArgument)
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=None,
         help="Enable sandboxing")

--- a/pym/bob/cmds/build/project.py
+++ b/pym/bob/cmds/build/project.py
@@ -16,6 +16,11 @@ from .builder import LocalBuilder
 from .state import DevelopDirOracle
 
 def doProject(argv, bobRoot):
+    def _downloadArg(arg):
+        if (arg.startswith("packages=") or arg in ['yes', 'no', 'deps']):
+            return arg
+        raise argparse.ArgumentTypeError("{} invalid.".format(arg))
+
     parser = argparse.ArgumentParser(prog="bob project", description='Generate Project Files')
     parser.add_argument('projectGenerator', nargs='?', help="Generator to use.")
     parser.add_argument('package', nargs='?', help="Sub-package that is the root of the project")
@@ -32,7 +37,8 @@ def doProject(argv, bobRoot):
     parser.add_argument('-E', dest="preserve_env", default=False, action='store_true',
         help="Preserve whole environment")
     parser.add_argument('--download', metavar="MODE", default="no",
-        help="Download from binary archive (yes, no, deps)", choices=['yes', 'no', 'deps'])
+        help="Download from binary archive (yes, no, deps, packages=<regular expression>)",
+        type=_downloadArg)
     parser.add_argument('--resume', default=False, action='store_true',
         help="Resume build where it was previously interrupted")
     parser.add_argument('-n', dest="execute_prebuild", default=True, action='store_false',


### PR DESCRIPTION
With download modules a regex can be used to specify which packages
should be downloaded.

Fixes #264