### PR TITLE
Show an error message for missing sphinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,33 +61,48 @@ setup_requires = [
 
 # Sphinx manpages and bash completion do not work on Windows
 if sys.platform != 'win32':
-    from sphinx.setup_command import BuildDoc
-    cmdclass['build_sphinx'] = BuildDoc
-    build.sub_commands.append(('build_sphinx', None))
-    setup_requires.append('sphinx')
-    data_files.extend([
-        ('share/man/man1', [
-            'doc/_build/man/bob-archive.1',
-            'doc/_build/man/bob-build.1',
-            'doc/_build/man/bob-clean.1',
-            'doc/_build/man/bob-dev.1',
-            'doc/_build/man/bob-graph.1',
-            'doc/_build/man/bob-jenkins.1',
-            'doc/_build/man/bob-ls.1',
-            'doc/_build/man/bob-project.1',
-            'doc/_build/man/bob-query-meta.1',
-            'doc/_build/man/bob-query-path.1',
-            'doc/_build/man/bob-query-recipe.1',
-            'doc/_build/man/bob-query-scm.1',
-            'doc/_build/man/bob-status.1',
-        ]),
-        ('share/man/man7', [
-            'doc/_build/man/bobpaths.7',
-        ]),
-        ('share/bash-completion/completions', [
-            'contrib/bash-completion/bob'
-        ]),
-    ])
+    try:
+        from sphinx.setup_command import BuildDoc
+        cmdclass['build_sphinx'] = BuildDoc
+        build.sub_commands.append(('build_sphinx', None))
+        setup_requires.append('sphinx')
+        data_files.extend([
+            ('share/man/man1', [
+                'doc/_build/man/bob-archive.1',
+                'doc/_build/man/bob-build.1',
+                'doc/_build/man/bob-clean.1',
+                'doc/_build/man/bob-dev.1',
+                'doc/_build/man/bob-graph.1',
+                'doc/_build/man/bob-jenkins.1',
+                'doc/_build/man/bob-ls.1',
+                'doc/_build/man/bob-project.1',
+                'doc/_build/man/bob-query-meta.1',
+                'doc/_build/man/bob-query-path.1',
+                'doc/_build/man/bob-query-recipe.1',
+                'doc/_build/man/bob-query-scm.1',
+                'doc/_build/man/bob-status.1',
+            ]),
+            ('share/man/man7', [
+                'doc/_build/man/bobpaths.7',
+            ]),
+            ('share/bash-completion/completions', [
+                'contrib/bash-completion/bob'
+            ]),
+        ])
+    except ImportError as e:
+        sys.exit("""=====================================================
+ You don't seem to have "sphinx" installed. "sphinx"
+ is needed for the generation of Bob's man pages.
+ Please run
+
+     pip install sphinx
+
+ and re-try
+
+     pip install BobBuildTool
+
+ afterwards.
+=====================================================""")
 
 # Sandbox helper is only built on Linux
 if sys.platform == "linux":


### PR DESCRIPTION
Since we have no proper way to interact with the user during install,
at least giving him or her an error message more human-readable than a
backtrace seems like a good idea.

There are two things that I've tried instead, to give a better onboarding experience - but that didn't work out:

* using `sphinx-pypi-upload` to pre-generate the man pages and push them individually to PyPI, but it seem - to put it mildly - unmaintained and it's in no way clear how it's _intended_ to work
* log an error message during install and then finish nevertheless, telling the user that if the man pages are actually needed, `pip install sphinx` followed by a `pip install --force-reinstall BobBuildTool` has to be run. This would also free the user from having to install `sphinx` in every `virtualenv`. Alas, modern versions of Pip don't let you log you at all, except for when the user adds `-v` to the command line, which doesn't seem like an appropriate idea.