### PR TITLE
jenkins: cleanup @tmp directories before build

### DIFF
--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -848,6 +848,10 @@ class JenkinsJob:
                         AUDIT=JenkinsJob._auditName(d),
                         WSP_PATH=d.getWorkspacePath()))
 
+        prepareCmds.append("# remove @tmp directories created by some jenkins plugins")
+        for d in sorted(self.__checkoutSteps.values()):
+            prepareCmds.append("rm -rf {}".format(" ".join(quote(d.getWorkspacePath() + "/" + s + "@tmp") for s in d.getScmDirectories())))
+
         # Create first "prepare" shell action. The actual command is set at the
         # end because the prepare commands are generated throughout the
         # generating process.


### PR DESCRIPTION
Some jenkins plugins create @tmp directories in the workspace for some
reasons. Remove them as they influence the buildId calculation.

Fixes #273