### PR TITLE
jenkins: fix encoding of username/password

### DIFF
--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -1560,11 +1560,15 @@ class JenkinsConnection:
                 context=ssl.SSLContext(ssl.PROTOCOL_SSLv23)))
 
         # handle authorization
-        if url.get("username"):
+        username = url.get("username")
+        if username is not None:
+            username = urllib.parse.unquote(username)
             passwd = url.get("password")
             if passwd is None:
                 passwd = getpass.getpass()
-            userPass = url["username"] + ":" + passwd
+            else:
+                passwd = urllib.parse.unquote(passwd)
+            userPass = username + ":" + passwd
             self.__headers['Authorization'] = 'Basic ' + base64.b64encode(
                 userPass.encode("utf-8")).decode("ascii")
 


### PR DESCRIPTION
Special characters in the username and password are percent encoded in
URLs. When constructing the 'Authorization' HTTP header these fields
must first be converted to UTF-8 before calculating the digest.

Fixes #277.