### PR TITLE
Fix detection of closing single quotation mark in StringParser

### DIFF
--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -81,13 +81,12 @@ class StringParser:
         i = self.index
         while i < self.end:
             if self.text[i] == "'":
-                i += 1
                 break
             i += 1
         if i >= self.end:
             raise ParseError("Missing closing \"'\"")
-        ret = self.text[self.index:i-1]
-        self.index = i
+        ret = self.text[self.index:i]
+        self.index = i+1
         return ret
 
     def getString(self, delim=[None], keep=False):

--- a/test/test_input_stringparser.py
+++ b/test/test_input_stringparser.py
@@ -38,6 +38,7 @@ class TestStringParser(TestCase):
 
     def testNoSubst(self):
         self.assertEqual(self.p.parse("string"), "string")
+        self.assertEqual(self.p.parse("'string'"), "string")
         self.assertEqual(self.p.parse('asdf"123"gf'), "asdf123gf")
         self.assertEqual(self.p.parse('a\'sd\'f"123"gf'), "asdf123gf")
 


### PR DESCRIPTION
There is a bug in function `getSingleQuoted()` of class `StringParser`, which ignores a closing single quotation mark, if it is at the end of the string. This bug is fixed.