### PR TITLE
Use function quote() from module shlex instead of pipes

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -22,7 +22,7 @@ concurrent uploads the artifact must appear atomically for unrelated readers.
 from .errors import BuildError
 from .tty import stepAction, SKIPPED, EXECUTED, WARNING, INFO, TRACE, ERROR
 from .utils import asHexStr, removePath, isWindows
-from pipes import quote
+from shlex import quote
 from tempfile import mkstemp, NamedTemporaryFile, TemporaryFile
 import argparse
 import asyncio

--- a/pym/bob/cmds/build/builder.py
+++ b/pym/bob/cmds/build/builder.py
@@ -14,7 +14,7 @@ from ...tty import log, stepMessage, stepAction, stepExec, setProgress, \
     ALWAYS, IMPORTANT, NORMAL, INFO, DEBUG, TRACE
 from ...utils import asHexStr, hashDirectory, removePath, emptyDirectory, \
     isWindows
-from pipes import quote
+from shlex import quote
 from textwrap import dedent
 import argparse
 import asyncio

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -11,7 +11,7 @@ from ..state import BobState
 from ..stringparser import isTrue
 from ..tty import WarnOnce
 from ..utils import asHexStr, processDefines
-from pipes import quote
+from shlex import quote
 import argparse
 import ast
 import base64

--- a/pym/bob/fingerprints.py
+++ b/pym/bob/fingerprints.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from pipes import quote
+from shlex import quote
 
 __all__ = ('mangleFingerprints')
 

--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -15,7 +15,7 @@ from os.path import expanduser
 from os.path import join
 from bob.utils import summonMagic, removePath
 from collections import OrderedDict
-from pipes import quote
+from shlex import quote
 
 # scan package recursivelely with its dependencies and build a list of checkout dirs
 def getCheckOutDirs(package, dirs):

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -20,7 +20,7 @@ from bob.errors import BuildError
 from bob.utils import summonMagic, hashFile
 from collections import OrderedDict, namedtuple
 from bob.tty import colorize
-from pipes import quote
+from shlex import quote
 
 # helper to get linux or windows (MSYS2 support) cwd
 pwd = None

--- a/pym/bob/generators/VisualStudio.py
+++ b/pym/bob/generators/VisualStudio.py
@@ -5,7 +5,7 @@
 
 from .common import CommonIDEGenerator
 from pathlib import Path, PureWindowsPath
-from pipes import quote
+from shlex import quote
 from uuid import UUID
 from uuid import uuid4 as randomUuid
 from uuid import uuid5 as sha1NsUuid

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -16,7 +16,7 @@ from abc import ABCMeta, abstractmethod
 from base64 import b64encode
 from itertools import chain
 from glob import glob
-from pipes import quote
+from shlex import quote
 from os.path import expanduser
 from string import Template
 from textwrap import dedent

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -8,7 +8,7 @@ from ..stringparser import isTrue
 from ..tty import WarnOnce, stepAction, INFO, TRACE, WARNING
 from ..utils import joinLines
 from .scm import Scm, ScmAudit, ScmStatus, ScmTaint
-from pipes import quote
+from shlex import quote
 from textwrap import dedent, indent
 from xml.etree import ElementTree
 import asyncio

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -7,7 +7,7 @@ from ..errors import ParseError
 from ..utils import joinLines
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from pipes import quote
+from shlex import quote
 import fnmatch
 import re
 

--- a/pym/bob/scm/svn.py
+++ b/pym/bob/scm/svn.py
@@ -6,7 +6,7 @@
 from ..errors import BuildError
 from ..utils import joinLines
 from .scm import Scm, ScmAudit, ScmTaint, ScmStatus
-from pipes import quote
+from shlex import quote
 from textwrap import indent
 import os, os.path
 import schema

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -6,7 +6,7 @@
 from ..errors import ParseError
 from ..utils import asHexStr, hashFile
 from .scm import Scm, ScmAudit
-from pipes import quote
+from shlex import quote
 import hashlib
 import os.path
 import re


### PR DESCRIPTION
Function `pipes.quote()` is deprecated since Python 2.7

see https://docs.python.org/2/library/pipes.html