### PR TITLE
generators: vs2019 add also local includes to include search paths

### DIFF
--- a/pym/bob/generators/VisualStudio.py
+++ b/pym/bob/generators/VisualStudio.py
@@ -147,6 +147,9 @@ class Project:
 
     def generateProject(self, projects, cmd):
         items = []
+        incPaths = []
+        if self.incPaths:
+            for i in self.incPaths: incPaths.append(str(i))
         if self.headers:
             g = ElementTree.Element("ItemGroup")
             for i in self.headers: ElementTree.SubElement(g, "ClInclude", {"Include" : str(i)})
@@ -159,7 +162,6 @@ class Project:
             g = ElementTree.ElementTree("ItemGroup")
             for i in self.resources: ElementTree.SubElement(g, "Text", {"Include" : str(i)})
             items.append(ElementTree.tostring(g, encoding="unicode"))
-        incPaths = []
         if self.dependencies:
             g = ElementTree.Element("ItemGroup")
             for i in sorted(self.dependencies):


### PR DESCRIPTION
Hi,

I added the local include paths of the module also to the include search paths for intellisense.
There was the problem, that !!SOME!! includes were not accessable by pressing F12 or STRG + left mouse button. (behavior was a bit strange, because some includes worked - but with this fix, all includes work fine).

BR.