### PR TITLE
Consistently use PEP 440 version numbers

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1427,7 +1427,15 @@ of the actual version number (e.g. "0.1.42"). Bob's version number is specified
 according to `Semantic Versioning`_. Therefore it is usually only needed to
 specify the major and minor version.
 
+The version string has to be compliant to Python `PEP 440`_. It is allowed to
+specify pre-release versions (e.g. ``0.16.0rc1``) and even development versions
+(e.g. ``0.15.1.dev42``). A version without pre-release suffix is considered
+more recent than a version with a pre-release suffix. The development release
+number is only relevant if the main version and the pre-release versions are
+equal.
+
 .. _Semantic Versioning: http://semver.org/
+.. _PEP 440: https://www.python.org/dev/peps/pep-0440/
 
 .. _configuration-config-layers:
 

--- a/doc/releases/0.16.rst
+++ b/doc/releases/0.16.rst
@@ -80,6 +80,12 @@ Recipes
   unneeded execution of identical fingerprint scripts. See the policy and the
   keyword for more details.
 
+* Added support for pre-release and development version numbers in
+  :ref:`configuration-bobMinimumVersion`.
+
+  Projects can now reliably require pre-release or development versions and do
+  not have to wait until the next release of Bob is published.
+
 User configuration (default.yaml)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pym/bob/develop/version.py
+++ b/pym/bob/develop/version.py
@@ -29,9 +29,18 @@ def getVersion():
             pass
 
     if version:
-        if re.match(r"^v[0-9]+(\.[0-9]+){2}(-.*)?$", version):
-            # strip white spaces and leading 'v' from tag name
-            version = version.strip().lstrip("v")
+        m = re.match(r"^v(?P<version>[0-9]+(?:\.[0-9]+){2})(?P<rc>-rc[0-9]+)?(?P<dist>-[0-9]+-g[a-f0-9]+)?(?P<dirty>-dirty)?$", version)
+        if m is not None:
+            # Convert to PEP 440 conforming version number
+            local = []
+            version = m.group("version")
+            if m.group("rc"): version += m.group("rc")[1:]
+            if m.group("dist"):
+                dist,commit = m.group("dist")[1:].split("-")
+                version += ".dev" + dist
+                local.append(commit)
+            if m.group("dirty"): local.append("dirty")
+            if local: version += "+" + ".".join(local)
         else:
             import sys
             print("Warning: inferred version of Bob does not match schema:",
@@ -39,8 +48,8 @@ def getVersion():
             version = ""
 
     if not version:
-        # Last fallback. See http://semver.org/ and adjust accordingly.
-        version = "0.16.0-unknown"
+        # Last fallback. See PEP 440 and adjust accordingly.
+        version = "0.16+unknown"
 
     return version
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2741,12 +2741,12 @@ class RecipeSet:
                     help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#securessl for more information.")
             ),
             'sandboxFingerprints' : (
-                "0.16",
+                "0.16rc1",
                 InfoOnce("sandboxFingerprints policy not set. Sandbox builds of fingerprinted packages are not shared with regular builds.",
                     help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#sandboxfingerprints for more information.")
             ),
             'fingerprintVars' : (
-                "0.16",
+                "0.16rc1",
                 InfoOnce("fingerprintVars policy not set. Fingerprint scripts may be run more often than needed.",
                     help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#fingerprintvars for more information.")
             ),

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2644,7 +2644,7 @@ class RecipeSet:
         })
 
     STATIC_CONFIG_SCHEMA = schema.Schema({
-        schema.Optional('bobMinimumVersion') : schema.Regex(r'^[0-9]+(\.[0-9]+){0,2}$'),
+        schema.Optional('bobMinimumVersion') : schema.Regex(r'^[0-9]+(\.[0-9]+){0,2}(rc[0-9]+)?(.dev[0-9]+)?$'),
         schema.Optional('plugins') : [str],
         schema.Optional('policies') : schema.Schema(
             {

--- a/test/test_develop_version.py
+++ b/test/test_develop_version.py
@@ -1,0 +1,42 @@
+# Bob build tool
+# Copyright (C) 2019  Jan Klötzke
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import patch
+import subprocess
+
+from bob.develop.version import getVersion
+
+
+class TestGitVersion(TestCase):
+
+    def testInvalid(self):
+        with patch("subprocess.check_output") as gitMock:
+            gitMock.side_effect = subprocess.CalledProcessError("git", "Error")
+            self.assertNotEqual(getVersion(), "")
+
+        with patch("subprocess.check_output") as gitMock:
+            gitMock.return_value = "garbage"
+            self.assertNotEqual(getVersion(), "")
+
+    def testVersions(self):
+        with patch("subprocess.check_output") as gitMock:
+            gitMock.return_value = "v0.1.2"
+            self.assertEqual(getVersion(), "0.1.2")
+            gitMock.return_value = "v1.2.3-rc10"
+            self.assertEqual(getVersion(), "1.2.3rc10")
+            gitMock.return_value = "v1.0.4-14-g2414721"
+            self.assertEqual(getVersion(), "1.0.4.dev14+g2414721")
+            gitMock.return_value = "v1.0.4-rc42-14-g2414721"
+            self.assertEqual(getVersion(), "1.0.4rc42.dev14+g2414721")
+
+            gitMock.return_value = "v0.1.2-dirty"
+            self.assertEqual(getVersion(), "0.1.2+dirty")
+            gitMock.return_value = "v1.2.3-rc10-dirty"
+            self.assertEqual(getVersion(), "1.2.3rc10+dirty")
+            gitMock.return_value = "v1.0.4-14-g2414721-dirty"
+            self.assertEqual(getVersion(), "1.0.4.dev14+g2414721.dirty")
+            gitMock.return_value = "v1.0.4-rc42-14-g2414721-dirty"
+            self.assertEqual(getVersion(), "1.0.4rc42.dev14+g2414721.dirty")


### PR DESCRIPTION
Convert git versions to PEP 440 versions. Change the version comparator to handle this format gracefully.

Fixes #290.