### PR TITLE
input: add support for if-expressions

### DIFF
--- a/doc/manpages/bobpaths.rst
+++ b/doc/manpages/bobpaths.rst
@@ -201,6 +201,7 @@ empty string, ``0`` and ``false`` (case insensitive) are treated as false. Any
 other string is converted to true.
 
 Location paths
+~~~~~~~~~~~~~~
     Relative location paths are evaluated with respect to the context package
     of the predicate expression. Absolute location paths are evaluated
     independent of that. If the location path yields an empty set of packages
@@ -213,7 +214,10 @@ Location paths
     matched by the location path". By this primitive arbitrary graph
     reachability relations may be expressed.
 
+.. _bobpaths_string_literals:
+
 String literals
+~~~~~~~~~~~~~~~
     Strings consist of a sequence of zero or more characters enclosed in double
     quotes (``"``). Strings are subject to the same
     :ref:`string substitution <configuration-principle-subst>` as in the
@@ -238,7 +242,10 @@ String literals
         "${ENABLED}"
         "$(match,${LICENSE},GPL)"
 
+.. _bobpaths_string_function_calls:
+
 String function calls
+~~~~~~~~~~~~~~~~~~~~~
     String functions may be called directly without relying on string
     substitution.  The general syntax is the funcion name, an opening
     parenthesis, zero or more arguments separated by comma and a closing

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -696,11 +696,14 @@ There are three common (string) attributes in all SCM specifications: ``scm``,
 ``dir`` and ``if``. By default the SCMs check out to the root of the workspace.
 You may specify any relative path in ``dir`` to checkout to this directory.
 
-By using ``if`` you can selectively enable or disable a particular SCM. The
-string given to the ``if``-keyword is substituted according to
-:ref:`configuration-principle-subst` and the final string is interpreted as a
-boolean value (everything except the empty string, ``0`` and ``false`` is
-considered true). The SCM will only be considered if the condition passes.
+By using ``if`` you can selectively enable or disable a particular SCM using
+either a string or a expression. In case a string is given to the ``if``-keyword
+it is substituted according to :ref:`configuration-principle-subst` and the final
+string is interpreted as a boolean value (everything except the empty string, ``0``
+and ``false`` is considered true). In case you're using the expression syntax you
+can use :ref:`bobpaths_string_literals` and :ref:`bobpaths_string_function_calls`
+to express a condition. The SCM will only be considered if the condition passes.
+
 
 Currently the following ``scm`` values are supported:
 
@@ -894,6 +897,19 @@ The following settings are supported:
 |             |                 |                                                     |
 |             |                 | Default: true                                       |
 +-------------+-----------------+-----------------------------------------------------+
+| if: !expr   | String          | The string is parsed as expression using the same   |
+|             |                 | :ref:`bobpaths_string_literals` and                 |
+|             |                 | :ref:`bobpaths_string_function_calls`               |
+|             |                 | as available for bobpaths.                          |
+|             |                 | The dependency is only considered if the expression |
+|             |                 | is considered as true.                              |
+|             |                 |                                                     |
+|             |                 | Default: true                                       |
+|             |                 | Example::                                           |
+|             |                 |                                                     |
+|             |                 |      if: !expr |                                    |
+|             |                 |            "${FOO}" == "bar" || "${BAZ}"            |
++-------------+-----------------+-----------------------------------------------------+
 
 .. _configuration-recipes-env:
 
@@ -1023,7 +1039,7 @@ supported by Bob.
 fingerprintIf
 ~~~~~~~~~~~~~
 
-Type: String | Boolean | ``null``
+Type: String | Boolean | ``null`` | IfExpression
 
 By default no fingerprinting is done unless at least one inherited class, used
 tool or the recipe explicitly enables it. This is done by either setting
@@ -1048,6 +1064,8 @@ Examples::
    fingerprintIf: True                       # unconditionally enable fingerprinting
    fingerprintIf: "$(eq,${TOOLCHAIN},host)"  # boolean experession
    fingerprintIf: null                       # same as if unset
+   fingerprintIf: !expr |                    # IfExpression
+                     "${TOOLCHAIN}" == "host"
 
 If not given it defaults to ``null``.
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -1816,7 +1816,7 @@ class Recipe(object):
                 use = dep.get("use", use)
                 newCond = dep.get("if")
                 if newCond is not None:
-                    cond = "$(and,{},{})".format(cond, newCond) if cond is not None else newCond
+                    cond = cond + [newCond] if cond is not None else [ newCond ]
                 name = dep.get("name")
                 if name:
                     if "depends" in dep:
@@ -2207,7 +2207,15 @@ class Recipe(object):
             env.setFunArgs({ "recipe" : self, "sandbox" : bool(sandbox) and sandboxEnabled,
                 "__tools" : tools })
 
-            if not env.evaluate(dep.condition, "dependency "+dep.recipe): continue
+            if dep.condition:
+                conditionsTrue = False
+                for cond in dep.condition:
+                    if not env.evaluate(cond, "dependency "+dep.recipe): break
+                else:
+                    conditionsTrue = True
+
+                if not conditionsTrue: continue
+
             r = self.__recipeSet.getRecipe(dep.recipe)
             try:
                 if r.__packageName in stack:

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..errors import ParseError, BuildError
-from ..stringparser import isTrue
+from ..stringparser import isTrue, IfExpression
 from ..tty import WarnOnce, stepAction, INFO, TRACE, WARNING
 from ..utils import joinLines
 from .scm import Scm, ScmAudit, ScmStatus, ScmTaint
@@ -26,7 +26,7 @@ class GitScm(Scm):
         'scm' : 'git',
         'url' : str,
         schema.Optional('dir') : str,
-        schema.Optional('if') : str,
+        schema.Optional('if') : schema.Or(str, IfExpression),
         schema.Optional('branch') : str,
         schema.Optional('tag') : str,
         schema.Optional('commit') : str,

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -38,7 +38,10 @@ class ScmOverride:
         for (key, value) in self.__match.items():
             if key not in scm: return False
             value = env.substitute(value, "svmOverride::match")
-            if not fnmatch.fnmatchcase(scm[key], value): return False
+            # the type of scm['if'] could be IfExpression and it is valid to compare the if keyword to match
+            # to a SCM. The old behavior of this is to compare the values as string rather than to evaluate it
+            # and compare the result. Casting the IfExpression to a str we do not change the behavior.
+            if not fnmatch.fnmatchcase(str(scm[key]), value): return False
         return True
 
     def __hash__(self):

--- a/pym/bob/scm/svn.py
+++ b/pym/bob/scm/svn.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..errors import BuildError
+from ..stringparser import IfExpression
 from ..utils import joinLines
 from .scm import Scm, ScmAudit, ScmTaint, ScmStatus
 from shlex import quote
@@ -19,7 +20,7 @@ class SvnScm(Scm):
         'scm' : 'svn',
         'url' : str,
         schema.Optional('dir') : str,
-        schema.Optional('if') : str,
+        schema.Optional('if') : schema.Or(str, IfExpression),
         schema.Optional('revision') : schema.Or(int, str),
         schema.Optional('sslVerify') : bool,
     })

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..errors import ParseError
+from ..stringparser import IfExpression
 from ..utils import asHexStr, hashFile
 from .scm import Scm, ScmAudit
 from shlex import quote
@@ -18,7 +19,7 @@ class UrlScm(Scm):
         'scm' : 'url',
         'url' : str,
         schema.Optional('dir') : str,
-        schema.Optional('if') : str,
+        schema.Optional('if') : schema.Or(str, IfExpression),
         schema.Optional('digestSHA1') : str,
         schema.Optional('digestSHA256') : str,
         schema.Optional('extract') : schema.Or(bool, str),

--- a/test/test_if_expression.py
+++ b/test/test_if_expression.py
@@ -1,0 +1,71 @@
+# Bob build tool
+# Copyright (C) 2020
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from bob.stringparser import DEFAULT_STRING_FUNS, Env, IfExpressionParser
+from bob.errors import BobError
+
+class TestIfExpressionParser(TestCase):
+
+    def setUp(self):
+        tools = {"a":1, "b":2}
+        self.__env = Env({"FOO" : "foo"
+            })
+        self.__env.setFuns(DEFAULT_STRING_FUNS.copy())
+        self.__env.setFunArgs({"sandbox" : False, "__tools" : tools})
+
+        self.__parser = IfExpressionParser()
+
+    def tearDown(self):
+        self.__parser = None
+
+    def parse(self, expr):
+        return self.__parser.evalExpression(expr, self.__env)
+
+    def testEqual(self):
+        self.assertRaises(BobError, self.parse, "x ==")
+        self.assertTrue(self.parse('"${FOO}" == "foo"'))
+        self.assertTrue(self.parse('"a" == "a"'))
+        self.assertFalse(self.parse('"a" == "b"'))
+
+    def testNotEqual(self):
+        self.assertRaises(BobError, self.parse, "x !=")
+        self.assertFalse(self.parse('"a" != "a"'))
+        self.assertTrue(self.parse('"a" != "b"'))
+
+    def testNot(self):
+        self.assertRaises(BobError, self.parse, "!")
+        self.assertFalse(self.parse('!"true"'))
+        self.assertFalse(self.parse("!'TRUE'"))
+        self.assertFalse(self.parse("!'1'"))
+        self.assertFalse(self.parse("!'foobar'"))
+        self.assertTrue(self.parse("!''"))
+        self.assertTrue(self.parse("!'0'"))
+        self.assertTrue(self.parse("!'false'"))
+        self.assertTrue(self.parse("!'FaLsE'"))
+
+    def testOr(self):
+        self.assertTrue( self.parse('"true" || "false"'))
+        self.assertTrue( self.parse('"false" || "true"'))
+        self.assertFalse(self.parse('"false" || "false"'))
+        self.assertTrue( self.parse('"1" || "2" || "3" || "4"'))
+        self.assertFalse(self.parse('"0" || "0"|| "0" || "0"'))
+        self.assertFalse(self.parse('"0" || "" || "false"'))
+
+    def testAnd(self):
+        self.assertTrue( self.parse('"true" && "true"'))
+        self.assertFalse(self.parse('"true" && "false"'))
+        self.assertFalse(self.parse('"false" && "true"'))
+        self.assertTrue( self.parse('"true" && "true" && "true"'))
+        self.assertTrue( self.parse('"true" && "1" && "abq"'))
+        self.assertFalse(self.parse('"true" && ""'))
+
+    def testFuns(self):
+        self.assertFalse(self.parse('is-sandbox-enabled()'))
+        self.assertTrue(self.parse('is-tool-defined("a")'))
+        self.assertFalse(self.parse('is-tool-defined("c")'))
+        self.assertFalse(self.parse('match( "string", "pattern")'))

--- a/test/test_input_recipe.py
+++ b/test/test_input_recipe.py
@@ -96,9 +96,9 @@ class TestDependencies(TestCase):
 
         self.assertEqual(len(res), 5)
         self.cmpEntry(res[0], "a")
-        self.cmpEntry(res[1], "b", cond="cond1")
-        self.cmpEntry(res[2], "c", cond="$(and,cond1,cond2)")
-        self.cmpEntry(res[3], "d", cond="cond1")
+        self.cmpEntry(res[1], "b", cond=["cond1"])
+        self.cmpEntry(res[2], "c", cond=["cond1","cond2"])
+        self.cmpEntry(res[3], "d", cond=["cond1"])
         self.cmpEntry(res[4], "e")
 
     def testNestedUse(self):


### PR DESCRIPTION
Support real expressions for the if property. This makes the if syntax
more readable.

E.g. instead of:
```
   if: "$(or,$(eq,${FOO},bar),${BAZ})"
```

you can now write:
```
   if: !expr |
      "${FOO}" == "bar" || "${BAZ}"
```