### PR TITLE
Query path options

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Bob'
-copyright = '2016-2019, The BobBuildTool Contributors'
+copyright = '2016-2020, The BobBuildTool Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/manpages/bob-query-path.rst
+++ b/doc/manpages/bob-query-path.rst
@@ -52,6 +52,9 @@ Options
 ``-q``
     Be quiet in case of errors
 
+``--fail``
+    Return a non-zero exit code in case of errors
+
 ``--no-sandbox``
     Disable sandboxing
 

--- a/doc/manpages/bob-query-path.rst
+++ b/doc/manpages/bob-query-path.rst
@@ -24,15 +24,22 @@ This command lists existing workspace directory names for packages given
 on the command line. Output is formatted with a format string that can
 contain placeholders
 
-   {name}     package name
-   {src}      checkout directory
-   {build}    build directory
-   {dist}     package directory
+    +----------+------------------+
+    |{name}    |package name      |
+    +----------+------------------+
+    |{src}     |checkout directory|
+    +----------+------------------+
+    |{build}   |build directory   |
+    +----------+------------------+
+    |{dist}    |package directory |
+    +----------+------------------+
 
 The default format is '{name}<tab>{dist}'.
 
 If a directory does not exist for a step (because that step has never
-been executed or does not exist), the line is omitted.
+been executed or does not exist) or if one or more of the given packages
+does not exist, a error message is printed unless the ``-q`` option is
+provided.
 
 Options
 -------

--- a/doc/manpages/bob-query-path.rst
+++ b/doc/manpages/bob-query-path.rst
@@ -49,6 +49,9 @@ Options
 ``-f FORMAT``
     Output format string
 
+``-q``
+    Be quiet in case of errors
+
 ``--no-sandbox``
     Disable sandboxing
 

--- a/pym/bob/cmds/build/query.py
+++ b/pym/bob/cmds/build/query.py
@@ -1,5 +1,5 @@
 # Bob build tool
-# Copyright (C) 2016-2019, The BobBuildTool Contributors
+# Copyright (C) 2016-2020, The BobBuildTool Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,6 +39,8 @@ been executed or does not exist), the line is omitted.
         help="Override default environment variable")
     parser.add_argument('-c', dest="configFile", default=[], action='append',
         help="Use config File")
+    parser.add_argument('-q', dest="quiet", action="store_true",
+        help="Be quiet in case of errors")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', help="Enable sandboxing")
@@ -82,7 +84,7 @@ been executed or does not exist), the line is omitted.
         def print(self):
             if (self.showPackage):
                 print(self.packageText)
-            else:
+            elif not args.quiet:
                 packageName = self.failedSteps[0].getPackage().getName()
                 if len(self.failedSteps) is 1:
                     print("Directory for {{{}}} step of package {} not present.".format(
@@ -133,5 +135,5 @@ been executed or does not exist), the line is omitted.
             # Show
             state.print()
 
-    if not matched:
+    if not matched and not args.quiet:
         print("Your query matched no packages. Naptime!", file=sys.stderr)

--- a/test/query-path/run.sh
+++ b/test/query-path/run.sh
@@ -17,6 +17,18 @@ test -z "$(run_bob query-path --release root)"
 test -z "$(run_bob query-path --release root/interm1/child)"
 test -z "$(run_bob query-path --release root/interm2/child)"
 
+# Still, must report error on stderr as long as we don't provide -q
+test -n "$(run_bob query-path --release root 2>&1 | grep 'not present')"
+test -n "$(run_bob query-path --release root/interm1/child 2>&1 | grep 'not present')"
+test -n "$(run_bob query-path --release root/interm2/child 2>&1 | grep 'not present')"
+test -z "$(run_bob query-path --release -q root 2>&1 | grep 'not present')"
+test -z "$(run_bob query-path --release -q root/interm1/child 2>&1 | grep 'not present')"
+test -z "$(run_bob query-path --release -q root/interm2/child 2>&1 | grep 'not present')"
+
+# Also, errors on non-present packages should be reported
+test -n "$(run_bob query-path --release notpresent 2>&1 | grep 'Naptime')"
+test -z "$(run_bob query-path --release -q notpresent 2>&1 | grep 'Naptime')"
+
 # Perform a full release build. Must report paths for everything.
 run_bob build root
 set -- $(run_bob query-path --release root)

--- a/test/query-path/run.sh
+++ b/test/query-path/run.sh
@@ -25,13 +25,19 @@ test -z "$(run_bob query-path --release -q root 2>&1 | grep 'not present')"
 test -z "$(run_bob query-path --release -q root/interm1/child 2>&1 | grep 'not present')"
 test -z "$(run_bob query-path --release -q root/interm2/child 2>&1 | grep 'not present')"
 
+# And must fail if --fail is provided
+expect_fail run_bob query-path --release --fail root
+expect_fail run_bob query-path --release --fail root/interm1/child
+expect_fail run_bob query-path --release --fail root/interm2/child
+
 # Also, errors on non-present packages should be reported
 test -n "$(run_bob query-path --release notpresent 2>&1 | grep 'Naptime')"
 test -z "$(run_bob query-path --release -q notpresent 2>&1 | grep 'Naptime')"
+expect_fail run_bob query-path --release --fail notpresent
 
 # Perform a full release build. Must report paths for everything.
 run_bob build root
-set -- $(run_bob query-path --release root)
+set -- $(run_bob query-path --release --fail root)
 test "$1" = "root"
 test "$2" = "work/root/dist/1/workspace"
 


### PR DESCRIPTION
This is a follow-up on #294 where we agreed on having both a `-q` and a `--fail` option for `bob query-path`.