### PR TITLE
setup: retain Python3.5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ if sys.platform != 'win32':
     build.sub_commands.append(('build_sphinx', None))
     setup_requires.extend([
         'sphinx',
-        'docutils<0.16' # https://github.com/sphinx-doc/sphinx/issues/6887
+        'docutils<0.16',    # https://github.com/sphinx-doc/sphinx/issues/6887
+        "Jinja2<3",         # Drops Python 3.5 compatibility
     ])
     data_files.extend([
         ('share/man/man1', [


### PR DESCRIPTION
The upcoming Jinja 3.0 version will require Python 3.6. Somehow the
Python3.5 pip will already fetch the alpha versions and fail badly.
Prevent that by requiring explicitly that Jinja2 must not be too new.