### PR TITLE
cvs scm: make command invocation work again

### DIFF
--- a/pym/bob/scm/cvs.py
+++ b/pym/bob/scm/cvs.py
@@ -63,14 +63,14 @@ class CvsScm(Scm):
             # We therefore use a 'cvs up' after the initial 'cvs co', to get the same behaviour for the initial and subsequent builds.
             if re.match('^:ext:', rootarg) and self.__dir == '.':
                 os.symlink(".", invoker.join("__tmp$$"))
-                invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "co"] + revarg +
+                await invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "co"] + revarg +
                     ["-d", "__tmp$$", self.__module], env=env)
                 os.unlink(invoker.join("__tmp$$"))
             else:
-                invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "co"] + revarg +
+                await invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "co"] + revarg +
                     ["-d", self.__dir, self.__module], env=env)
 
-        invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "up", "-dP"] + revarg +
+        await invoker.checkCommand(["cvs", "-qz3", "-d", rootarg, "up", "-dP"] + revarg +
             [self.__dir], env=env)
 
     def asDigestScript(self):


### PR DESCRIPTION
The rework in 4e488a75 forgot to 'await' the commands, causing a warning to
be generated and the command being not executed:

    cvs.py:74: RuntimeWarning: coroutine 'Invoker.checkCommand' was never awaited

----

In case this was a canary whether I'm still using it: of course I do! I even build MS-DOS programs with it now! :-)