### PR TITLE
travis: fix CI build for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
     - pip install schema
     - pip install python-magic
     - pip install pyparsing
+    - pip install sphinx
 
 script:
     - eatmydata ./test/run-tests.sh

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,6 @@ if sys.platform != 'win32':
     build.sub_commands.append(('build_sphinx', None))
     setup_requires.extend([
         'sphinx',
-        'docutils<0.16',    # https://github.com/sphinx-doc/sphinx/issues/6887
-        "Jinja2<3",         # Drops Python 3.5 compatibility
     ])
     data_files.extend([
         ('share/man/man1', [


### PR DESCRIPTION
Somehow the setuptools seem to download pre-release versions of
dependencies that are named in 'setup_requires'. This has been a hassle
before and now it fails again on some 'markupsafe' alpha version. Let's
try to install the sphinx dependency upfront with pip which should avoid
pre-release versions by default.