### PR TITLE
builder: add simple make jobserver

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1248,7 +1248,19 @@ All attributes of the class are merged with the attributes of the current
 recipe. If the order is important the attributes of the class are put in front
 of the respective attributes of the recipe. For example the scripts of the
 inherited class of all steps are inserted in front of the scripts of the
-current recipe. 
+current recipe.
+
+jobServer
+~~~~~~~~~
+
+Type: Boolean
+
+Pass MAKEFLAGS Environment variable to the executed script with ``-j`` and
+``--jobserver-auth`` set. This enables submakes or other tools to use Bobs
+internal jobserver or even the jobserver of make calling bob. Bob also participating
+and not starting any new step as long as no ticket is available.
+
+Not available on Windows.
 
 .. _configuration-recipes-metaenv:
 

--- a/pym/bob/invoker.py
+++ b/pym/bob/invoker.py
@@ -17,6 +17,7 @@ import datetime
 import io
 import locale
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -89,6 +90,8 @@ class Invoker:
                                          if k in spec.envWhiteList }
         self.__logFileName = None if noLogFiles else spec.logFile
         self.__logFile = DEVNULL
+        self.__makeFds = []
+        self.__makeJobs = None
         self.__trace = trace
         self.__sandboxHelperPath = None
         self.__stdioBuffer = io.BytesIO() if redirect else None
@@ -225,7 +228,7 @@ class Invoker:
                 *args,
                 stdin=self.__stdin, stdout=stdoutRedir, stderr=stderrRedir,
                 env=env, cwd=cwd,
-                **kwargs)
+                **kwargs, pass_fds=self.__makeFds)
         except OSError as e:
             self.fail(str(e), returncode=127)
 
@@ -305,6 +308,16 @@ class Invoker:
                 os.makedirs(self.__spec.workspaceWorkspacePath, exist_ok=True)
             elif clean and mode != InvocationMode.SHELL:
                 emptyDirectory(self.__spec.workspaceWorkspacePath)
+
+            if len(self.__makeFds) == 2:
+                makeFlags = self.__spec.env.get("MAKEFLAGS")
+                if makeFlags is not None:
+                    makeFlags = re.sub(r'-j\s*[0-9]*', '', makeFlags)
+                    makeFlags = re.sub(r'--jobserver-auth=[0-9]*,[0-9]*', '', makeFlags)
+                else:
+                    makeFlags = ""
+                self.__spec.env["MAKEFLAGS"] = (makeFlags + " -j" + str(self.__makeJobs)
+                    + " --jobserver-auth=" + ",".join([str(fd) for fd in self.__makeFds]))
 
             # setup script and arguments
             if mode == InvocationMode.SHELL:
@@ -537,3 +550,6 @@ class Invoker:
         return self.__stdioBuffer.getvalue().decode(
             locale.getpreferredencoding(), 'surrogateescape')
 
+    def setMakeParameters(self, fds, jobs):
+        self.__makeFds = fds
+        self.__makeJobs = jobs

--- a/test/test_cmd_build_builder_jobserver.py
+++ b/test/test_cmd_build_builder_jobserver.py
@@ -1,0 +1,35 @@
+
+from unittest import TestCase
+from bob.cmds.build.builder import InternalJobServer, JobServerSemaphore
+import asyncio
+
+class TestJobServer:
+    def __init__(self):
+        self.__jobServer = InternalJobServer (2)
+        self.__jobServerSem = JobServerSemaphore(self.__jobServer.getMakeFd(), False)
+
+    async def testAcquire (self, cnt = 1):
+        while cnt != 0:
+            await self.__jobServerSem.acquire()
+            cnt -= 1
+
+    def release(self):
+        self.__jobServerSem.release()
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+class TestJobserverTest (TestCase):
+    def setUp (self):
+        self.__t = TestJobServer()
+
+    def testAcquire(self):
+        _run(self.__t.testAcquire())
+        self.__t.release()
+        _run(self.__t.testAcquire(2))
+        self.__t.release()
+        self.__t.release()
+
+    def testReleaseToOften(self):
+        with self.assertRaises(ValueError):
+            self.__t.release()


### PR DESCRIPTION
The make jobserver mechanism need two pipes. As long as it can read from
the request pipe new jobs are started. Once a job has finished a byte is
written back into the response pipe.

fixes: #257