### PR TITLE
input: prevent folding of empty packages in graph

### DIFF
--- a/test/stable-variant-ids/specs/env.txt
+++ b/test/stable-variant-ids/specs/env.txt
@@ -22,6 +22,9 @@ root-env/env::b dist 80cef8d63497bb87a4188d177a7113eecab4d08e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-env/env::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-env/env::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-env/env::d dist 04c2dc89930141de2a7b5bda91476772af6dfb71
   digestScript: 9718449ab965b52c8c40ce526f7b2c86b6d25b22
   env:
@@ -29,3 +32,6 @@ root-env/env::d dist 04c2dc89930141de2a7b5bda91476772af6dfb71
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-env/env::d build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-env/env::d src 8696cf0f4655636cc93c566c1be2dad311da646c

--- a/test/stable-variant-ids/specs/include.txt
+++ b/test/stable-variant-ids/specs/include.txt
@@ -3,3 +3,6 @@ root-include dist fb565cbb8d2ea1010dfebef0ff23e32fc57de915
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-include build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-include src 8696cf0f4655636cc93c566c1be2dad311da646c

--- a/test/stable-variant-ids/specs/sandbox.txt
+++ b/test/stable-variant-ids/specs/sandbox.txt
@@ -32,16 +32,25 @@ root-sandbox/lib-a/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-a/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/lib-a/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/tool1 dist d12d07b3f21af04d681be28fdd0a7e4fd6ae22b2
   digestScript: 1e88b888d7e4b2eb60d72236f8f025f144ed362c
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/tool1 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/tool1 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/tool1 dist d12d07b3f21af04d681be28fdd0a7e4fd6ae22b2
   digestScript: 1e88b888d7e4b2eb60d72236f8f025f144ed362c
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/tool1 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/tool1 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-b dist a8662e6cf119a39c5009a1569ec4aea940cf63ac
   digestScript: a849444484353357c9fafe1bc7f4d9bfe0d80614
   sandbox: b0ba704481711cba94c6c026f73374a100581080
@@ -60,6 +69,9 @@ root-sandbox/lib-b/lib2 dist cfca1f6505a5e1fa25e2677c22651c34c4abd8e2
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-b/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/lib-b/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -78,21 +90,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -111,21 +135,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -144,21 +180,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-c dist ccea96fc362a10ab870c28b0f17d5391a9d866e7
   digestScript: 1d469e8d00a44fe9e1e19b32cebdc95f0eacc602
   sandbox: b0ba704481711cba94c6c026f73374a100581080
@@ -177,6 +225,9 @@ root-sandbox/lib-c/lib2 dist cfca1f6505a5e1fa25e2677c22651c34c4abd8e2
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-c/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/lib-c/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -195,21 +246,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -228,21 +291,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -261,27 +336,42 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-b/lib2 dist cfca1f6505a5e1fa25e2677c22651c34c4abd8e2
   digestScript: 6bc695bf91c5e7b4259dbb189781665444a2e7b4
   sandbox: b0ba704481711cba94c6c026f73374a100581080
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/lib-b/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/lib-b/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -300,21 +390,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -333,21 +435,33 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a dist b0ba704481711cba94c6c026f73374a100581080
   digestScript: 72c5a85fe641f9ace8baaea160c5ca5237c0627a
   sandbox: 5bf1be130044488bd6629c199c7f2ed6db720c8a
@@ -366,18 +480,30 @@ root-sandbox/sandbox::a/tool6 dist 70ad92e2338030c5cb45a3dabd7bf243bdbc717e
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool6 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool6 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 dist 4c8299a650fc5fd2019d36907230f7828643fffb
   digestScript: 110c2cd5f46edbdd0b720a8e811eccc8d28779ae
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/tool7 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/tool7 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b dist 5bf1be130044488bd6629c199c7f2ed6db720c8a
   digestScript: e3cfcdf75515e39f35c918d396aa33e87c26606b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-sandbox/sandbox::a/sandbox::b build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-sandbox/sandbox::a/sandbox::b src 8696cf0f4655636cc93c566c1be2dad311da646c

--- a/test/stable-variant-ids/specs/tools.txt
+++ b/test/stable-variant-ids/specs/tools.txt
@@ -35,16 +35,25 @@ root-tools/lib-a/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-a/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-a/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool1 dist d12d07b3f21af04d681be28fdd0a7e4fd6ae22b2
   digestScript: 1e88b888d7e4b2eb60d72236f8f025f144ed362c
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool1 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool1 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool1 dist d12d07b3f21af04d681be28fdd0a7e4fd6ae22b2
   digestScript: 1e88b888d7e4b2eb60d72236f8f025f144ed362c
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool1 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool1 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-b dist d233ef09c1ab2d47b6f195c3d32dde1a740374ab
   digestScript: a849444484353357c9fafe1bc7f4d9bfe0d80614
   tools:
@@ -62,11 +71,17 @@ root-tools/lib-b/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-b/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-b/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool2 dist aca45611d748aa59ee047874f05406e726338309
   digestScript: 0af6da5d4bd908414b1fc2708ac57f2c3b9b5720
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-c dist ef9b30b9ad1b68886202f5190353abe7cc56b1f4
   digestScript: 1d469e8d00a44fe9e1e19b32cebdc95f0eacc602
   tools:
@@ -86,16 +101,25 @@ root-tools/lib-c/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-c/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-c/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool3 dist eb5616a62ce663bc2864b5a1cc0668fab07ee8bc
   digestScript: 4e446787bb6ecf81e23692369ba0d592c817b54b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool3 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool3 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool3 dist eb5616a62ce663bc2864b5a1cc0668fab07ee8bc
   digestScript: 4e446787bb6ecf81e23692369ba0d592c817b54b
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool3 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool3 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-d dist 68fc967d580ffcf6474ddfd408b9152b59e6cd83
   digestScript: 73f3e2c71cd769785c00046fef85e6051f94a5cf
   tools:
@@ -115,16 +139,25 @@ root-tools/lib-d/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-d/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-d/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 dist 602999aafdc7c527dbcb73cd6b331463231c3c33
   digestScript: a46ce207990f71df688d5c75205d2372381c7024
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool4 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 dist 602999aafdc7c527dbcb73cd6b331463231c3c33
   digestScript: a46ce207990f71df688d5c75205d2372381c7024
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool4 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-e dist b4ad8a005ca7011109d04c4ed3e3c2f62b7a80e6
   digestScript: 41a1167c7514ba6a44c9d72d0567d315e7fff66d
   tools:
@@ -143,16 +176,25 @@ root-tools/lib-e/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-e/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-e/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 dist 602999aafdc7c527dbcb73cd6b331463231c3c33
   digestScript: a46ce207990f71df688d5c75205d2372381c7024
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool4 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool4 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool5 dist c995b1a90b92916f33cba293c9a56c4909d5eca9
   digestScript: 718c3ff5c9afd3a846e7bb20ad207663ab0bf3b6
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/tool5 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/tool5 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-f dist 70be83970bfa73ea67e50f88a3a9745e614e7325
   digestScript: d56e6d6d92f2952f06e97753bf5d41f979c4c0ab
   args:
@@ -168,6 +210,9 @@ root-tools/lib-f/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-f/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-f/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-g dist ab657770625569737a5a847e8fed80b5a86bb5e2
   digestScript: 2e9c87ef5953674816219183c0ac712c4d3206c0
   args:
@@ -183,6 +228,9 @@ root-tools/lib-g/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-g/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-g/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-h dist b893133fa4fd142ac24d804c2e83139c93975435
   digestScript: 6d14100cc838fb6e3c3685d8b4a48c7a859692a2
   args:
@@ -198,8 +246,14 @@ root-tools/lib-h/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-h/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-h/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-a/lib2 dist 4201679bda4aab0d12d0ad4440849260634013a5
   digestScript: 6bc695bf91c5e7b4259dbb189781665444a2e7b4
   args:
     8696cf0f4655636cc93c566c1be2dad311da646c
 root-tools/lib-a/lib2 build 8696cf0f4655636cc93c566c1be2dad311da646c
+  args:
+    8696cf0f4655636cc93c566c1be2dad311da646c
+root-tools/lib-a/lib2 src 8696cf0f4655636cc93c566c1be2dad311da646c


### PR DESCRIPTION
If a package has no buildScript then the results of the dependencies do
not contribute to the package content. It is still possible to build
deeper packages explicitly, though. Unfortunately the package graph
collapsed these empty packages during optimization even if the
sub-packages constituted different variants. This lead to incorrect
builds if multiple variants of dependencies from recipes without
a buildScript were defined.

Fixes #332.