### PR TITLE
scm/url: Include User-Agent

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -1,5 +1,5 @@
 # Bob build tool
-# Copyright (C) 2016  Jan Klötzke
+# Copyright (C) 2016-2020 The BobBuildTool Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -19,6 +19,7 @@ it must not be overwritten. The backend should make sure that even on
 concurrent uploads the artifact must appear atomically for unrelated readers.
 """
 
+from . import BOB_VERSION
 from .errors import BuildError
 from .tty import stepAction, stepMessage, \
     SKIPPED, EXECUTED, WARNING, INFO, TRACE, ERROR, IMPORTANT
@@ -572,7 +573,8 @@ class SimpleHttpArchive(BaseArchive):
     def __openDownloadFile(self, buildId, suffix):
         connection = self._getConnection()
         url = self._makeUrl(buildId, suffix)
-        connection.request("GET", url)
+        connection.request("GET", url,
+                headers={ 'User-Agent' : 'BobBuildTool/{}'.format(BOB_VERSION) })
         response = connection.getresponse()
         if response.status == 200:
             return SimpleHttpDownloader(self, response)
@@ -596,7 +598,8 @@ class SimpleHttpArchive(BaseArchive):
         url = self._makeUrl(buildId, suffix)
 
         # check if already there
-        connection.request("HEAD", url)
+        connection.request("HEAD", url,
+                headers={ 'User-Agent' : 'BobBuildTool/{}'.format(BOB_VERSION) })
         response = connection.getresponse()
         response.read()
         if response.status == 200:
@@ -622,7 +625,7 @@ class SimpleHttpArchive(BaseArchive):
         tmp.seek(0)
         connection = self._getConnection()
         connection.request("PUT", url, tmp, headers={ 'Content-Length' : length,
-            'If-None-Match' : '*' })
+            'If-None-Match' : '*', 'User-Agent' : 'BobBuildTool/{}'.format(BOB_VERSION) })
         response = connection.getresponse()
         response.read()
         if response.status == 412:

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -1,5 +1,5 @@
 # Bob build tool
-# Copyright (C) 2016  Jan Klötzke
+# Copyright (C) 2016-2020 The BobBuildTool Contributors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from .. import BOB_VERSION
 from ..errors import BuildError, ParseError
 from ..stringparser import IfExpression
 from ..utils import asHexStr, hashFile, isWindows
@@ -207,6 +208,7 @@ class UrlScm(Scm):
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         headers = {}
+        headers["User-Agent"] = "BobBuildTool/{}".format(BOB_VERSION)
         context = None if self.__sslVerify else ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         if os.path.isfile(destination) and self.__url.startswith("http"):
             # Try to avoid download if possible


### PR DESCRIPTION
Apparently, some hosts filter out the User-Agent set by urllib by
default, so we should include our own. For debugging purposes it's
probably a good idea to also include the current version, to identify
misbehaving changes.

The host this issue aroused with in this particular case is
https://swupdate.openvpn.org/, but of course this could happen
anywhere else, too.