### PR TITLE
Fix format character for os.stat_result.st_ino in DirHasher.FileIndex.CACHE_ENTRY_FMT

### DIFF
--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -231,7 +231,7 @@ class DirHasher:
 
     class FileIndex:
         SIGNATURE        = b'BOB1'
-        CACHE_ENTRY_FMT  = '=QQLqLQ20sH'
+        CACHE_ENTRY_FMT  = '=QQLQLQ20sH'
         CACHE_ENTRY_SIZE = struct.calcsize(CACHE_ENTRY_FMT)
 
         class Stat:

--- a/test/test_utils_dirhasher.py
+++ b/test/test_utils_dirhasher.py
@@ -111,7 +111,7 @@ class TestHashDir(TestCase):
 
         s = MagicMock()
         s.st_mode=33188
-        s.st_ino=-5345198597064824875
+        s.st_ino=15345198597064824875
         s.st_dev=65027
         s.st_nlink=1
         s.st_uid=1000


### PR DESCRIPTION
We observed a Python exception in function `DirHasher.FileIndex.__writeEntry()` on a newly updated MSYS2 platform:

```
Bob version 0.16.0
Traceback (most recent call last):
  File "/home/dachselt/bob/pym/bob/scripts.py", line 120, in catchErrors
    ret = fun(*args, **kwargs)
  File "/home/dachselt/bob/pym/bob/scripts.py", line 222, in cmd
    cmd(args.args, bobRoot)
  File "/home/dachselt/bob/pym/bob/scripts.py", line 27, in __develop
    doDevelop(*args, **kwargs)
  File "/home/dachselt/bob/pym/bob/cmds/build/build.py", line 288, in doDevelop
    commonBuildDevelop(parser, argv, bobRoot, True)
  File "/home/dachselt/bob/pym/bob/cmds/build/build.py", line 234, in commonBuildDevelop
    builder.cook(backlog, True if args.build_mode == 'checkout-only' else False)
  File "/home/dachselt/bob/pym/bob/cmds/build/builder.py", line 931, in cook
    raise self.__buildErrors[0]
  File "/home/dachselt/bob/pym/bob/cmds/build/builder.py", line 833, in __taskWrapper
    ret = await coro()
  File "/home/dachselt/bob/pym/bob/cmds/build/builder.py", line 990, in _cookStep
    await self._cookBuildStep(step, checkoutOnly, depth)
  File "/home/dachselt/bob/pym/bob/cmds/build/builder.py", line 1218, in _cookBuildStep
    buildHash = hashWorkspace(buildStep)
  File "/home/dachselt/bob/pym/bob/cmds/build/builder.py", line 50, in hashWorkspace
    return hashDirectory(step.getWorkspacePath(),
  File "/home/dachselt/bob/pym/bob/utils.py", line 378, in hashDirectory
    return DirHasher(index, ignoreDirs).hashDirectory(path)
  File "/home/dachselt/bob/pym/bob/utils.py", line 358, in hashDirectory
    return self.__hashDir(os.fsencode(path))
  File "/home/dachselt/bob/pym/bob/utils.py", line 346, in __hashDir
    dirList = [
  File "/home/dachselt/bob/pym/bob/utils.py", line 347, in <listcomp>
    (struct.pack("=L", s.st_mode) + self.__hashEntry(prefix, e, s) + f)
  File "/home/dachselt/bob/pym/bob/utils.py", line 300, in __hashEntry
    digest = self.__hashDir(prefix, entry)
  File "/home/dachselt/bob/pym/bob/utils.py", line 346, in __hashDir
    dirList = [
  File "/home/dachselt/bob/pym/bob/utils.py", line 347, in <listcomp>
    (struct.pack("=L", s.st_mode) + self.__hashEntry(prefix, e, s) + f)
  File "/home/dachselt/bob/pym/bob/utils.py", line 300, in __hashEntry
    digest = self.__hashDir(prefix, entry)
  File "/home/dachselt/bob/pym/bob/utils.py", line 346, in __hashDir
    dirList = [
  File "/home/dachselt/bob/pym/bob/utils.py", line 347, in <listcomp>
    (struct.pack("=L", s.st_mode) + self.__hashEntry(prefix, e, s) + f)
  File "/home/dachselt/bob/pym/bob/utils.py", line 298, in __hashEntry
    digest = self.__index.check(prefix, entry, s, hashFile)
  File "/home/dachselt/bob/pym/bob/utils.py", line 270, in check
    self.__writeEntry(name, st, digest)
  File "/home/dachselt/bob/pym/bob/utils.py", line 247, in __writeEntry
    self.__outFile.write(struct.pack(DirHasher.FileIndex.CACHE_ENTRY_FMT, float2ns(st.st_ctime),
struct.error: argument out of range
```

The exception cause could be isolated to argument `st.st_ino` of function call `struct.pack()`. According to the format string `DirHasher.FileIndex.CACHE_ENTRY_FMT` this argument is expected to be a signed 64-Bit value (format character `q` = type `long long`, see [*Format characters*](https://docs.python.org/3/library/struct.html?highlight=struct%20pack#format-characters)), but the observed Windows file index was in the range `2^63 ... 2^64-1` and thus was unsigned.

As can be seen in commit 8e33389, the format character for argument `st.st_ino` has already been changed from `L` to `q` in the past. But this doesn't seem to be sufficient. According to the documentation for [Window file indices](https://msdn.microsoft.com/en-us/library/aa363788), these are 64-Bit values and Python seems to handle them as unsigned values (which actually makes sense for an index).