### PR TITLE
Small bob archive improvements

### DIFF
--- a/doc/manpages/bob-archive.rst
+++ b/doc/manpages/bob-archive.rst
@@ -23,8 +23,8 @@ Available sub-commands:
 
 ::
 
-    bob archive clean [-h] [--dry-run] [-n] [-v] expression
-    bob archive scan [-h] [-v]
+    bob archive clean [-h] [--dry-run] [-n] [-v] [-f] expression
+    bob archive scan [-h] [-v] [-f]
 
 Description
 -----------
@@ -51,6 +51,9 @@ Options
 
 ``-v``
     Be a bit more chatty on what is done.
+
+``-f``
+    Return a non-zero exit code in case of errors
 
 Commands
 --------

--- a/pym/bob/cmds/archive.py
+++ b/pym/bob/cmds/archive.py
@@ -14,6 +14,7 @@ import pickle
 import pyparsing
 import re
 import sqlite3
+import sys
 import tarfile
 
 # need to enable this for nested expression parsing performance
@@ -77,6 +78,7 @@ class ArchiveScanner:
 
     def scan(self, verbose):
         try:
+            found = False
             self.__db.execute("BEGIN")
             for l1 in os.listdir("."):
                 if not self.__dirSchema.fullmatch(l1): continue
@@ -86,11 +88,16 @@ class ArchiveScanner:
                     for l3 in os.listdir(l2):
                         m = self.__archiveSchema.fullmatch(l3)
                         if not m: continue
+                        found = True
                         self.__scan(os.path.join(l2, l3), verbose)
         except OSError as e:
             raise BobError("Error scanning archive: " + str(e))
         finally:
             self.__db.execute("END")
+            if verbose and not found:
+                print("Your archive seems to be empty. "
+                      "Are you running 'bob archive' from within the correct directory?",
+                      file=sys.stderr)
 
     def __scan(self, fileName, verbose):
         try:

--- a/pym/bob/cmds/archive.py
+++ b/pym/bob/cmds/archive.py
@@ -98,6 +98,7 @@ class ArchiveScanner:
                 print("Your archive seems to be empty. "
                       "Are you running 'bob archive' from within the correct directory?",
                       file=sys.stderr)
+            return found
 
     def __scan(self, fileName, verbose):
         try:
@@ -294,11 +295,14 @@ def doArchiveScan(argv):
     parser = argparse.ArgumentParser(prog="bob archive scan")
     parser.add_argument("-v", "--verbose", action='store_true',
         help="Verbose operation")
+    parser.add_argument("-f", "--fail", action='store_true',
+        help="Return a non-zero error code in case of errors")
     args = parser.parse_args(argv)
 
     scanner = ArchiveScanner()
     with scanner:
-        scanner.scan(args.verbose)
+        if not scanner.scan(args.verbose) and args.fail:
+            sys.exit(1)
 
 
 # meta.package == "root" && build.date > "2017-06-19"
@@ -331,6 +335,8 @@ def doArchiveClean(argv):
         help="Skip scanning for new artifacts")
     parser.add_argument("-v", "--verbose", action='store_true',
         help="Verbose operation")
+    parser.add_argument("-f", "--fail", action='store_true',
+        help="Return a non-zero error code in case of errors")
     args = parser.parse_args(argv)
 
     try:
@@ -342,7 +348,8 @@ def doArchiveClean(argv):
     retained = set()
     with scanner:
         if not args.noscan:
-            scanner.scan(args.verbose)
+            if not scanner.scan(args.verbose) and args.fail:
+                sys.exit(1)
         for bid in scanner.getBuildIds():
             if bid in retained: continue
             if retainExpr.evalBool(scanner.getVars(bid)):

--- a/test/archive/run.sh
+++ b/test/archive/run.sh
@@ -41,5 +41,9 @@ touch 64/ad/aabbcc-too-short.tgz
 run_bob archive scan
 popd
 
+# Test that -v doesn't catch fire
+run_bob archive scan -v
+run_bob archive clean -v 'metaEnv.TYPE == "alpha"'
+
 # Copy coverage data from archive directory (if any).
 cp $archiveDir/.coverage* . 2>/dev/null || true

--- a/test/archive/run.sh
+++ b/test/archive/run.sh
@@ -45,5 +45,13 @@ popd
 run_bob archive scan -v
 run_bob archive clean -v 'metaEnv.TYPE == "alpha"'
 
+# Test for --fail option
+expect_fail run_bob archive scan --fail -v
+expect_fail run_bob archive clean --fail -v 'metaEnv.TYPE == "alpha"'
+pushd $archiveDir
+run_bob archive scan --fail -v
+run_bob archive clean --fail -v 'metaEnv.TYPE == "alpha"'
+popd
+
 # Copy coverage data from archive directory (if any).
 cp $archiveDir/.coverage* . 2>/dev/null || true


### PR DESCRIPTION
This adds both a warning message when there haven't been any archive files found and a `--fail` option analogous to `bob query-path`.

I'm a bit unsure whether or not the `--fail` option should be a bit more aggressive, though, for example while detecting "wrong" files. I am happily awaiting feedback on this point.

Fixes #339