### PR TITLE
Tool remapping

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1026,6 +1026,20 @@ The following settings are supported:
 |             |                 |      if: !expr |                                    |
 |             |                 |            "${FOO}" == "bar" || "${BAZ}"            |
 +-------------+-----------------+-----------------------------------------------------+
+| tools       | Dictionary      | Remap an existing tool to another name, possibly    |
+|             | (String ->      | replacing the other tool. This is useful to change  |
+|             | String)         | tools for a single dependency, e.g. using the host  |
+|             |                 | toolchain for the dependency instead of the current |
+|             |                 | cross compiling toolchain. Example::                |
+|             |                 |                                                     |
+|             |                 |     tools:                                          |
+|             |                 |         target-toolchain: host-toolchain            |
+|             |                 |                                                     |
+|             |                 | This will replace ``target-toolchain`` for the      |
+|             |                 | dependency with the current ``host-toolchain``.     |
+|             |                 | At the dependency both names will refer to the same |
+|             |                 | tool.                                               |
++-------------+-----------------+-----------------------------------------------------+
 
 .. _configuration-recipes-env:
 

--- a/test/tools-rename/config.yaml
+++ b/test/tools-rename/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.17"

--- a/test/tools-rename/output/result.txt
+++ b/test/tools-rename/output/result.txt
@@ -1,0 +1,34 @@
+user-tool+1, unknown, unknown
+user-tool+2, a, a
+user-tool+3, b, b
+user-a+1, a, a
+user-b+1, b, b
+user-c+1, unknown, unknown
+user-tool+4, a, a
+user-b+2, b, b
+user-a+2, b, b
+user-b+3, a, a
+sub-1: user-tool+1, b, b
+sub-1: user-a+1, a, a
+sub-1: user-b+1, b, b
+sub-1: user-c+1, unknown, unknown
+sub-1: user-tool+2, a, a
+sub-1: user-c+2, a, a
+sub-1: user-tool+3, c, c
+sub-1: user-tool+4, b, b
+sub-1: user-a+2, b, b
+sub-1: user-b+2, c, c
+sub-1: user-c+3, a, a
+sub-2: user-tool+1, b, b
+sub-2: user-a+1, b, b
+sub-2: user-b+1, a, a
+sub-2: user-c+1, unknown, unknown
+sub-2: user-tool+2, b, b
+sub-2: user-c+2, b, b
+sub-2: user-tool+3, c, c
+sub-2: user-tool+4, a, a
+sub-2: user-a+2, a, a
+sub-2: user-b+2, c, c
+sub-2: user-c+3, b, b
+user-c+2, b, b
+user-tool+5, b, b

--- a/test/tools-rename/recipes/root.yaml
+++ b/test/tools-rename/recipes/root.yaml
@@ -1,0 +1,57 @@
+root: True
+depends:
+    - user-tool+1 # "unknown"
+
+    - name: tools-a
+      use: [tools]
+      forward: True
+
+    - user-tool+2 # "a"
+
+    - name: tools-b
+      use: [tools]
+      forward: True
+
+    - user-tool+3 # "b"
+    - user-a+1 # "a"
+    - user-b+1 # "b"
+    - user-c+1 # "unknown"
+
+    - name: user-tool+4 # "a"
+      tools:
+        tool: tool-a
+    - name: user-b+2 # "b"
+      tools:
+        tool: tool-a
+
+    - name: user-a+2 # "b"
+      tools:
+        tool-a: tool-b
+        tool-b: tool-a
+    - name: user-b+3 # "a"
+      tools:
+        tool-a: tool-b
+        tool-b: tool-a
+
+    - sub-1
+    - name: sub-2
+      tools:
+        tool-a: tool-b
+        tool-b: tool-a
+
+    - name: user-c+2 # "b"
+      tools:
+        tool-c: tool-b
+
+    - name: user-tool+5 # "b"
+      tools:
+        tool: tool
+
+buildScript: |
+    rm -f result.txt
+    for i in "${@:2}" ; do
+        cat "$i/result.txt" >> result.txt
+    done
+
+packageScript: |
+    cp "$1/result.txt" .

--- a/test/tools-rename/recipes/sub.yaml
+++ b/test/tools-rename/recipes/sub.yaml
@@ -1,0 +1,57 @@
+depends:
+    - user-tool+1 # b
+    - user-a+1 # a / b
+    - user-b+1 # b / a
+    - user-c+1 # unknown / unknown
+
+    - name: user-tool+2 # a / b
+      tools:
+        tool: tool-a
+
+    - name: user-c+2 # a / b
+      tools:
+        tool-c: tool-a
+
+    - name: tools-c
+      use: [tools]
+      forward: True
+
+    - user-tool+3 # c / c
+    - name: user-tool+4 # b / a
+      tools:
+        tool: tool-b
+
+    - tools:
+        tool-c: tool-a
+        tool-a: tool-b
+        tool-b: tool-c
+      depends:
+        - user-a+2 # b / a
+        - user-b+2 # c / c
+        - user-c+3 # a / b
+
+buildVars: [BOB_PACKAGE_NAME]
+buildScript: |
+    rm -f result.txt
+    for i in "${@:2}" ; do
+        echo -n "$BOB_PACKAGE_NAME: " >> result.txt
+        cat "$i/result.txt" >> result.txt
+    done
+
+packageScript: |
+    cp "$1/result.txt" .
+
+multiPackage:
+    # Expects that
+    #   tool == tool-b
+    #   tool-a exists and yields "a"
+    #   tool-b exists and yields "b"
+    #   tool-c does not exist
+    "1": {}
+
+    # Expects that
+    #   tool == tool-b
+    #   tool-a exists and yields "b"
+    #   tool-b exists and yields "a"
+    #   tool-c does not exist
+    "2": {}

--- a/test/tools-rename/recipes/tools.yaml
+++ b/test/tools-rename/recipes/tools.yaml
@@ -1,0 +1,40 @@
+multiPackage:
+    a:
+        packageScript: |
+            printf "#!/bin/sh\necho a" > tool.sh
+            chmod +x tool.sh
+        provideTools:
+            tool:
+                path: "."
+                environment:
+                    TOOL: "a"
+            tool-a:
+                path: "."
+                environment:
+                    TOOL: "a"
+    b:
+        packageScript: |
+            printf "#!/bin/sh\necho b" > tool.sh
+            chmod +x tool.sh
+        provideTools:
+            tool:
+                path: "."
+                environment:
+                    TOOL: "b"
+            tool-b:
+                path: "."
+                environment:
+                    TOOL: "b"
+    c:
+        packageScript: |
+            printf "#!/bin/sh\necho c" > tool.sh
+            chmod +x tool.sh
+        provideTools:
+            tool:
+                path: "."
+                environment:
+                    TOOL: "c"
+            tool-c:
+                path: "."
+                environment:
+                    TOOL: "c"

--- a/test/tools-rename/recipes/user.yaml
+++ b/test/tools-rename/recipes/user.yaml
@@ -1,0 +1,36 @@
+multiPackage:
+    tool+1:
+        packageTools: [tool]
+    tool+2:
+        packageTools: [tool]
+    tool+3:
+        packageTools: [tool]
+    tool+4:
+        packageTools: [tool]
+    tool+5:
+        packageTools: [tool]
+    a+1:
+        packageTools: [tool-a]
+    a+2:
+        packageTools: [tool-a]
+    a+3:
+        packageTools: [tool-a]
+    b+1:
+        packageTools: [tool-b]
+    b+2:
+        packageTools: [tool-b]
+    b+3:
+        packageTools: [tool-b]
+    c+1:
+        packageTools: [tool-c]
+    c+2:
+        packageTools: [tool-c]
+    c+3:
+        packageTools: [tool-c]
+
+packageVars: [BOB_PACKAGE_NAME, TOOL]
+packageScript: |
+    (
+        echo -n "$BOB_PACKAGE_NAME, ${TOOL:-unknown}, "
+        tool.sh 2>/dev/null || echo unknown
+    ) > result.txt

--- a/test/tools-rename/run.sh
+++ b/test/tools-rename/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+
+# Tests the different aspects of tool remapping for dependencies.
+
+exec_blackbox_test


### PR DESCRIPTION
Support remapping/replacing a tool by an existing one. This comes in handy when a dependency needs to be built by the host toolchain instead of the currently active cross toolchain.

Lays the ground to handle BobBuildTool/basement#11.