### PR TITLE
Add "show" command

### DIFF
--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -29,7 +29,8 @@ __bob_complete_dir()
                  compgen -d -P "$2" -S / -- "$1" ) )
 }
 
-__bob_commands="build dev clean graph help jenkins ls project status  query-scm query-recipe query-path query-meta"
+__bob_commands="build dev clean graph help jenkins ls project status  query-scm \
+                query-recipe query-path query-meta show"
 
 # Complete a Bob path
 #
@@ -351,6 +352,26 @@ __bob_query_recipe()
 __bob_status()
 {
   __bob_complete_path "--attic --develop --recursive --no-sandbox --release --sandbox --show-clean --show-overrides --verbose -D -c -r -v"
+}
+
+__bob_show()
+{
+    if [[ "$prev" = "--format" ]] ; then
+        __bob_complete_words "yaml json flat diff"
+    elif [[ "$prev" = "-f" ]] ; then
+        __bob_complete_words "buildNetAccess buildTools buildToolsWeak
+            buildVars buildVarsWeak checkoutAssert checkoutDeterministic
+            checkoutSCM checkoutTools checkoutToolsWeak checkoutVars
+            checkoutVarsWeak depends fingerprintIf jobServer meta
+            metaEnvironment packageNetAccess packageTools packageToolsWeak
+            packageVars packageVarsWeak relocatable root sandbox scriptLanguage
+            shared"
+    elif [[ "$prev" = "--indent" ]] ; then
+        COMPREPLY=( )
+    else
+        __bob_complete_path "-D -c --sandbox --no-sandbox --show-empty
+            --show-common --indent --no-indent --format -f"
+    fi
 }
 
 __bob_subcommands()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,6 +268,7 @@ man_pages = [
     ('manpages/bob-query-path', 'bob-query-path', 'Query path information', ['Jan Klötzke'], 1),
     ('manpages/bob-query-recipe', 'bob-query-recipe', 'Query package sources', ['Jan Klötzke'], 1),
     ('manpages/bob-query-scm', 'bob-query-scm', 'Query SCM information', ['Jan Klötzke'], 1),
+    ('manpages/bob-show', 'bob-show', 'Show properties of a package', ['Jan Klötzke'], 1),
     ('manpages/bob-status', 'bob-status', 'Show SCM status', ['Jan Klötzke'], 1),
 ]
 

--- a/doc/manpages/bob-show.rst
+++ b/doc/manpages/bob-show.rst
@@ -1,0 +1,96 @@
+.. _manpage-show:
+
+bob-show
+========
+
+.. only:: not man
+
+   Name
+   ----
+
+   bob-show - Show properties of a package
+
+Synopsis
+--------
+
+::
+
+    bob show [-h] [-D DEFINES] [-c CONFIGFILE] [--sandbox | --no-sandbox]
+             [--show-empty] [--show-common] [--indent INDENT | --no-indent]
+             [--format {yaml,json,flat,diff}]
+             [-f {buildNetAccess,buildTools,buildToolsWeak,buildVars,buildVarsWeak,
+                  checkoutAssert,checkoutDeterministic,checkoutSCM,checkoutTools,
+                  checkoutToolsWeak,checkoutVars,checkoutVarsWeak,depends,
+                  fingerprintIf,jobServer,meta,metaEnvironment,packageNetAccess,
+                  packageTools,packageToolsWeak,packageVars,packageVarsWeak,
+                  relocatable,root,sandbox,scriptLanguage,shared}]
+             packages [packages ...]
+
+
+Description
+-----------
+
+Show properties of one or more packages. Most properties are the same that
+are specified in the recipes. This command will show the final values of the
+properties that are used at build time. Additionally to the recipe properties
+the following synthetic properties are shown:
+
+* ``meta``: Map of sub-properties that describe the package
+
+   * ``deterministic``: True if Bob thinks the package is fully reproducible.
+     False if some input of the package is variable.
+   * ``name``: The package name
+   * ``package``: The package path
+   * ``recipe``: The recipe name that created this package
+   * ``checkoutVariantId``: The variant-Id of the package step. Different
+     checkout variant-Ids are always checked out separately.
+   * ``buildVariantId``: The variant-Id of the build step.
+   * ``packageVariantId``: The variant-Id of the package. See
+     :ref:`implicit versioning concepts <concepts-implicit-versioning>` for
+     more details.
+
+* ``sandbox``: The sandbox package that is used for this package.
+
+By default the information is shown as YAML document. If multiple packages are
+selected then multiple YAML documents are generated too. The output format can
+be controlled with the ``--format`` option. The ``flat`` format is a custom
+output format where each key/value pair is printed on a separate line.
+
+The ``diff`` output mode is special because it compares two packages and shows
+the properties that are different between both packages.
+
+Options
+-------
+
+``-f FIELD``
+   Show only the given ``FIELD``. This option may be specified more than once
+   to show additional fields. If this option is not given then all fields are
+   show.
+
+``--format {yaml,json,flat,diff}``
+   Selects a different output format. Defaults to ``yaml``.
+
+``--indent INDENT``
+   The ``yaml`` and ``json`` output formats are pretty printed with an
+   indentation of 4 spaces by default. Use this option to chance this to
+   ``INDENT`` number of spaces.
+
+``--no-indent``
+   Disables the pretty printing of the ``yaml`` and ``json`` formats. The
+   output will be more compact but is less readable.
+
+``--no-sandbox``
+   Disable sandboxing.
+
+``--sandbox``
+   Enable sandboxing.
+
+``--show-common``
+   The ``diff`` format suppresses identical fields by default. This option
+   forces them to be shown.
+
+``--show-empty``
+   By default empty or disabled properties are filtered out to keep the output
+   as short as possible. Specifying this option will still show them. If the
+   package does not have a checkout- or build-step the respective properties do
+   not exist and will never be shown.

--- a/doc/manpages/index.rst
+++ b/doc/manpages/index.rst
@@ -19,5 +19,6 @@ Contents:
    bob-query-path
    bob-query-recipe
    bob-query-scm
+   bob-show
    bob-status
 

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -840,6 +840,14 @@ url    While not a real SCM it      | ``url``: File that should be downloaded
                                                            (optional, tar files only)
 ====== ============================ =======================================================================================
 
+The following synthetic attributes exist. They are generated internally
+and cannot be set in the recipe. They are intended to be matched in queries
+or to show additional information.
+
+* ``overridden``: Boolean that is true if a :ref:`configuration-config-scmOverrides`
+  was applied. Otherwise false.
+* ``recipe``: The file name of the recipe/class that defined this SCM
+
 .. _Git: http://git-scm.com/
 .. _Svn: http://subversion.apache.org/
 
@@ -2016,6 +2024,10 @@ If an override is matching the actions are then applied in the following order:
 All overrides values are mangled through :ref:`configuration-principle-subst`. Mangling is
 performed during calculation of the checkoutStep so that the full environment for this step is
 available for substitution.
+
+When an override is applied the ``overridden`` property of the SCM is set to
+true. This property can be used with the ``matchScm`` function in package
+queries to find packages whose SCM(s) have been overridden.
 
 alias
 ~~~~~

--- a/pym/bob/cmds/show.py
+++ b/pym/bob/cmds/show.py
@@ -1,0 +1,309 @@
+# Bob build tool
+# Copyright (C) 2020  Jan Klötzke
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from ..errors import ParseError
+from ..input import RecipeSet
+from ..tty import colorize, ADDED, DELETED, DEFAULT, ADDED_HIGHLIGHT, DELETED_HIGHLIGHT
+from ..utils import asHexStr, processDefines
+import argparse
+import difflib
+import json
+import sys
+import yaml
+
+ALL_FIELDS = (
+    "buildNetAccess", "buildTools", "buildToolsWeak", "buildVars",
+    "buildVarsWeak", "checkoutAssert", "checkoutDeterministic", "checkoutSCM",
+    "checkoutTools", "checkoutToolsWeak", "checkoutVars", "checkoutVarsWeak",
+    "depends", "fingerprintIf", "jobServer", "meta", "metaEnvironment",
+    "packageNetAccess", "packageTools", "packageToolsWeak", "packageVars",
+    "packageVarsWeak", "relocatable", "root", "sandbox", "scriptLanguage",
+    "shared",
+)
+
+def dumpPackage(package):
+    recipe = package.getRecipe()
+
+    doc = {
+        "meta" : {
+            "name" : package.getName(),
+            "recipe" : recipe.getName(),
+            "package" : "/".join(package.getStack()),
+            "deterministic" : package.getPackageStep().isDeterministic(),
+        },
+        "scriptLanguage" : recipe.scriptLanguage.index.value,
+        "shared" : recipe.isShared(),
+        "metaEnvironment" : package.getMetaEnv(),
+        "relocatable" : package.isRelocatable(),
+        "jobServer" : recipe.jobServer(),
+        "root" : recipe.isRoot(),
+    }
+
+    checkoutStep = package.getCheckoutStep()
+    if checkoutStep.isValid():
+        doc["meta"]["checkoutVariantId"] = asHexStr(checkoutStep.getVariantId())
+        doc["checkoutDeterministic"] = checkoutStep.isDeterministic()
+        doc["checkoutSCM"] = [
+            { k:v for k,v in s.getProperties(False).items() if not k.startswith("__") }
+            for s in checkoutStep.getScmList()
+        ]
+        doc["checkoutAssert"] = [
+            { k:v for k,v in a.getProperties().items() if not k.startswith("__") }
+            for a in recipe.checkoutAsserts
+        ]
+        doc["checkoutTools"] = {
+            name : "/".join(t.getStep().getPackage().getStack())
+            for name, t in checkoutStep.getTools().items()
+            if name in recipe.toolDepCheckout
+        }
+        doc["checkoutToolsWeak"] = {
+            name : "/".join(t.getStep().getPackage().getStack())
+            for name, t in checkoutStep.getTools().items()
+            if name in recipe.toolDepCheckoutWeak
+        }
+        doc["checkoutVars"] = {
+            k : v for k, v in checkoutStep.getEnv().items()
+            if k in recipe.checkoutVars
+        }
+        doc["checkoutVarsWeak"] = {
+            k : v for k, v in checkoutStep.getEnv().items()
+            if k in recipe.checkoutVarsWeak
+        }
+
+    buildStep = package.getBuildStep()
+    if buildStep.isValid():
+        doc["meta"]["buildVariantId"] = asHexStr(buildStep.getVariantId())
+        doc["buildNetAccess"] = buildStep.hasNetAccess()
+        doc["depends"] = [
+            "/".join(d.getPackage().getStack())
+            for d in buildStep.getArguments()[1:]
+        ]
+        doc["buildTools"] = {
+            name : "/".join(t.getStep().getPackage().getStack())
+            for name, t in buildStep.getTools().items()
+            if name in recipe.toolDepBuild
+        }
+        doc["buildToolsWeak"] = {
+            name : "/".join(t.getStep().getPackage().getStack())
+            for name, t in buildStep.getTools().items()
+            if name in recipe.toolDepBuildWeak
+        }
+        doc["buildVars"] = {
+            k : v for k, v in buildStep.getEnv().items()
+            if k in recipe.buildVars
+        }
+        doc["buildVarsWeak"] = {
+            k : v for k, v in buildStep.getEnv().items()
+            if k in recipe.buildVarsWeak
+        }
+
+    packageStep = package.getPackageStep()
+    doc["meta"]["packageVariantId"] = asHexStr(packageStep.getVariantId())
+    doc["packageTools"] = {
+        name : "/".join(t.getStep().getPackage().getStack())
+        for name, t in packageStep.getTools().items()
+        if name in recipe.toolDepPackage
+    }
+    doc["packageToolsWeak"] = {
+        name : "/".join(t.getStep().getPackage().getStack())
+        for name, t in packageStep.getTools().items()
+        if name in recipe.toolDepPackageWeak
+    }
+    doc["packageVars"] = {
+        k : v for k, v in packageStep.getEnv().items()
+        if k in recipe.packageVars
+    }
+    doc["packageVarsWeak"] = {
+        k : v for k, v in packageStep.getEnv().items()
+        if k in recipe.packageVarsWeak
+    }
+    doc["packageNetAccess"] = packageStep.hasNetAccess()
+    doc["fingerprintIf"] = packageStep._isFingerprinted()
+
+    sandbox = packageStep.getSandbox()
+    if sandbox and sandbox.isEnabled():
+        doc["sandbox"] = "/".join(sandbox.getStep().getPackage().getStack())
+    else:
+        doc["sandbox"] = None
+
+    return doc
+
+def filterEmpty(doc):
+    if isinstance(doc, dict):
+        return { k : filterEmpty(v) for k, v in doc.items() if v }
+    elif isinstance(doc, list):
+        return [ filterEmpty(v) for v in doc ]
+    else:
+        return doc
+
+def filterFields(doc, fields):
+    if not fields:
+        return doc
+    else:
+        return { k:v for k,v in doc.items() if k in fields }
+
+def showPackagesYaml(docs, indent):
+    if indent is None:
+        style = None
+    else:
+        style = False
+
+    return "\n".join(
+        "--- # {}\n{}".format(package,
+                              yaml.dump(doc, default_flow_style=style, indent=indent))
+        for package, doc in docs)
+
+def showPackagesJson(docs, indent):
+    docs = [ doc for _package, doc in docs ]
+    if len(docs) == 1:
+        docs = docs[0]
+    return json.dumps(docs, indent=indent, sort_keys=True)
+
+def _showPackageFlat(doc, prefix=""):
+    ret = []
+    if isinstance(doc, dict):
+        for k,v in sorted(doc.items()):
+            ret.extend(_showPackageFlat(v, prefix+"."+k if prefix else k))
+    elif isinstance(doc, list):
+        i = 0
+        for v in doc:
+            ret.extend(_showPackageFlat(v, "{}[{}]".format(prefix, i)))
+            i += 1
+    else:
+        ret = [ "{}={!r}".format(prefix, doc) ]
+    return ret
+
+def showPackagesFlat(docs):
+    ret = []
+    for package, doc in docs:
+        ret.append("[" + package + "]")
+        ret.extend(_showPackageFlat(doc))
+        ret.append("")
+
+    return "\n".join(ret)
+
+def getSegments(indicator):
+    mode = False
+    start = 0
+    end = 1
+    ret = []
+    for c in indicator[2:]:
+        newMode = c != " "
+        end += 1
+        if mode != newMode:
+            ret.append((mode, start, end))
+            mode = newMode
+            start = end
+    ret.append((mode, start, end+1))
+    return ret
+
+def diffPackages(left, right, show_common):
+    left = [ l+"\n" for l in _showPackageFlat(left) ]
+    right = [ l+"\n" for l in _showPackageFlat(right) ]
+    diff = [ l for l in difflib.Differ().compare(left, right)
+             if not l.startswith("  ") or show_common ]
+
+    # Colorize lines with the intraline information from difflib. A bit
+    # complicated because the affected characters are specified with the next
+    # line. If the intraline diff is too big then no context is given.
+    prevLine = origPrevLine = None
+    ret = []
+    for l in diff:
+        nextLine = origNextLine = l.rstrip()
+        if nextLine.startswith("? "):
+            if origPrevLine.startswith("+ "):
+                codes = { False : ADDED, True : ADDED_HIGHLIGHT }
+            elif origPrevLine.startswith("- "):
+                codes = { False : DELETED, True : DELETED_HIGHLIGHT }
+            else:
+                codes = { False : DEFAULT, True : DEFAULT }
+
+            res = ""
+            for mode, start, end in getSegments(nextLine):
+                res += colorize(origPrevLine[start:end], codes[mode])
+            if end < len(origPrevLine):
+                res += colorize(origPrevLine[end:], codes[False])
+            prevLine = res
+            nextLine = origNextLine = None
+        elif nextLine.startswith("+ "):
+            nextLine = colorize(nextLine, ADDED)
+        elif nextLine.startswith("- "):
+            nextLine = colorize(nextLine, DELETED)
+
+        if prevLine is not None: ret.append(prevLine)
+        prevLine = nextLine
+        origPrevLine = origNextLine
+
+    if prevLine is not None:
+        ret.append(prevLine)
+
+    return "\n".join(ret)
+
+def doShow(argv, bobRoot):
+    parser = argparse.ArgumentParser(prog="bob show",
+        description="Show properties of one or more packages.")
+    parser.add_argument('packages', nargs='+', help="(Sub-)packages to query")
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
+    parser.add_argument('-c', dest="configFile", default=[], action='append',
+        help="Use config File")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--sandbox', action='store_true', default=False,
+        help="Enable sandboxing")
+    group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
+        help="Disable sandboxing")
+
+    group = parser.add_argument_group('output', "Appearance and content of output")
+    group.add_argument('--show-empty', action='store_true', default=False,
+        help="Also show empty properties")
+    group.add_argument('--show-common', action='store_true', default=False,
+        help="Also show unchanged attributes in diff format")
+    ex = group.add_mutually_exclusive_group()
+    ex.add_argument('--indent', type=int, default=4,
+        help="Number of spaces to indent (default: 4)")
+    ex.add_argument('--no-indent', action='store_const', const=None,
+        dest='indent', help="No indent. Compact format.")
+    group.add_argument('--format', choices=['yaml', 'json', 'flat', 'diff'],
+        default="yaml", help="Output format")
+    group.add_argument('-f', dest='field', action='append',
+        choices=sorted(ALL_FIELDS),
+        help="Show particular field(s) instead of all")
+
+    args = parser.parse_args(argv)
+    defines = processDefines(args.defines)
+
+    recipes = RecipeSet()
+    recipes.setConfigFiles(args.configFile)
+    recipes.parse()
+    packages = recipes.generatePackages(lambda s,m: "unused", defines, args.sandbox)
+
+    if not args.show_empty:
+        filt = filterEmpty
+    else:
+        filt = lambda x: x
+
+    if args.field:
+        filt = lambda x, filt=filt: filterFields(filt(x), args.field)
+
+    docs = []
+    for p in args.packages:
+        for package in packages.queryPackagePath(p):
+            docs.append(("/".join(package.getStack()), filt(dumpPackage(package))))
+
+    if not docs:
+        print("Your query matched no packets!", file=sys.stderr)
+        ret = None
+    elif args.format == 'yaml':
+        ret = showPackagesYaml(docs, args.indent)
+    elif args.format == 'json':
+        ret = showPackagesJson(docs, args.indent)
+    elif args.format == 'flat':
+        ret = showPackagesFlat(docs)
+    elif len(docs) != 2:
+        raise ParseError("Diff format requires exactly two packages")
+    else:
+        ret = diffPackages(docs[0][1], docs[1][1], args.show_common)
+
+    if ret: print(ret)

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2720,6 +2720,14 @@ Every dependency must only be given once."""
         return [ CheckoutAssert(cassert) for cassert in self.__checkoutAsserts ]
 
     @property
+    def checkoutVars(self):
+        return self.__checkoutVars
+
+    @property
+    def checkoutVarsWeak(self):
+        return self.__checkoutVarsWeak - self.__checkoutVars
+
+    @property
     def buildScript(self):
         return self.__build[0]
 
@@ -2728,12 +2736,28 @@ Every dependency must only be given once."""
         return self.__build[1]
 
     @property
+    def buildVars(self):
+        return self.__buildVars
+
+    @property
+    def buildVarsWeak(self):
+        return self.__buildVarsWeak - self.__buildVars
+
+    @property
     def packageScript(self):
         return self.__package[0]
 
     @property
     def packageDigestScript(self):
         return self.__package[1]
+
+    @property
+    def packageVars(self):
+        return self.__packageVars
+
+    @property
+    def packageVarsWeak(self):
+        return self.__packageVarsWeak - self.__packageVars
 
     @property
     def toolDepCheckout(self):

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -647,7 +647,7 @@ class CoreSandbox(CoreItem):
         self.mounts.extend(recipeSet.getSandboxMounts())
         self.environment = {
             k : env.substitute(v, "providedSandbox::environment")
-            for (k, v) in spec.get('environment', {})
+            for (k, v) in spec.get('environment', {}).items()
         }
 
         # Calculate a "resultId" so that only identical sandboxes match

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -7,7 +7,8 @@ from . import BOB_VERSION, BOB_INPUT_HASH, DEBUG
 from .errors import ParseError, BobError
 from .languages import getLanguage, ScriptLanguage, BashLanguage, PwshLanguage
 from .pathspec import PackageSet
-from .scm import CvsScm, GitScm, ImportScm, SvnScm, UrlScm, ScmOverride, auditFromDir, getScm
+from .scm import CvsScm, GitScm, ImportScm, SvnScm, UrlScm, ScmOverride, \
+    auditFromDir, getScm, SYNTHETIC_SCM_PROPS
 from .state import BobState
 from .stringparser import checkGlobList, Env, DEFAULT_STRING_FUNS, IfExpression
 from .tty import InfoOnce, Warn, WarnOnce, setColorMode
@@ -354,7 +355,7 @@ def Scm(spec, env, overrides, recipeSet):
     if matchedOverrides:
         try:
             recipeSet.SCM_SCHEMA.validate({ k:v for k,v in spec.items()
-                if k != '__source' and k != 'recipe' })
+                if k not in SYNTHETIC_SCM_PROPS })
         except schema.SchemaError as e:
             raise ParseError("Error validating SCM after applying scmOverrides: {}".format(str(e)))
 

--- a/pym/bob/scm/__init__.py
+++ b/pym/bob/scm/__init__.py
@@ -13,7 +13,7 @@ from .url import UrlScm, UrlAudit
 import os.path
 import schema
 
-SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe'))
+SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe', 'overridden'))
 
 async def auditFromDir(dir):
     if os.path.isdir(os.path.join(dir, ".git")):

--- a/pym/bob/scm/__init__.py
+++ b/pym/bob/scm/__init__.py
@@ -13,6 +13,8 @@ from .url import UrlScm, UrlAudit
 import os.path
 import schema
 
+SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe'))
+
 async def auditFromDir(dir):
     if os.path.isdir(os.path.join(dir, ".git")):
         return await GitAudit.fromDir(dir, ".", {})

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -217,6 +217,7 @@ class Scm(metaclass=ABCMeta):
         return self.__source
 
     def getProperties(self, isJenkins):
+        # XXX: keep in sync with bob.scm.SYNTHETIC_SCM_PROPS
         return {
             "__source" : self.__source,
             "recipe" : self.__recipe,

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -221,6 +221,7 @@ class Scm(metaclass=ABCMeta):
         return {
             "__source" : self.__source,
             "recipe" : self.__recipe,
+            "overridden" : bool(self.__overrides),
         }
 
     @abstractmethod

--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -59,6 +59,11 @@ def __project(*args, **kwargs):
      doProject(*args, **kwargs)
      return 0
 
+def __show(*args, **kwars):
+     from .cmds.show import doShow
+     doShow(*args, **kwars)
+     return 0
+
 def __status(*args, **kwars):
      from .cmds.build.status import doStatus
      doStatus(*args, **kwars)
@@ -108,6 +113,7 @@ availableCommands = {
     "jenkins"       : ('hl', __jenkins, "Configure Jenkins server"),
     "ls"            : ('hl', __ls, "List package hierarchy"),
     "project"       : ('hl', __project, "Create project files"),
+    "show"          : ('hl', __show, "Show properties of a package"),
     "status"        : ('hl', __status, "Show SCM status"),
 
     "query-scm"     : ('ll', __queryscm, "Query SCM information"),

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -608,7 +608,14 @@ def funMatchScm(args, **options):
         raise ParseError('matchScm can only be used for queries')
 
     for scm in pkg.getCheckoutStep().getScmList():
-        if fnmatch.fnmatchcase(scm.getProperties().get(name), val): return "true"
+        prop = scm.getProperties(False).get(name)
+        if isinstance(prop, str):
+            if fnmatch.fnmatchcase(str(prop), val): return "true"
+        elif isinstance(prop, bool):
+            # Need to compare bool before int because bool is a subclass of int
+            if isTrue(val) == prop: return "true"
+        elif isinstance(prop, int):
+            if prop == int(val, 0): return "true"
 
     return "false"
 

--- a/pym/bob/tty.py
+++ b/pym/bob/tty.py
@@ -13,6 +13,12 @@ WARNING = 4
 ERROR = 5
 HEADLINE = 6
 
+# The following color codes are only intended for package diffs
+ADDED = 7
+ADDED_HIGHLIGHT = 8
+DELETED = 9
+DELETED_HIGHLIGHT = 10
+
 ALWAYS = -2
 IMPORTANT = -1
 NORMAL = 0
@@ -20,7 +26,7 @@ INFO = 1
 DEBUG = 2
 TRACE = 3
 
-COLORS2CODE = [ "", "", "32", "34", "33", "31", "32;1" ]
+COLORS2CODE = [ "", "", "32", "34", "33", "31", "32;1", "32", "1;32;48;5;22", "31", "1;31;48;5;52" ]
 COLORS2TEXT = [ "NOTE", "NOTE", "NOTE", "INFO", "WARN", "ERR ", "====" ]
 
 def colorize(string, color):

--- a/test/sandbox/recipes/root.yaml
+++ b/test/sandbox/recipes/root.yaml
@@ -9,5 +9,7 @@ checkoutScript: |
     echo ok
 buildScript: |
     echo ok
+packageVars: [FOO]
 packageScript: |
+    test $FOO = bar
     echo ok

--- a/test/sandbox/recipes/sandbox.yaml
+++ b/test/sandbox/recipes/sandbox.yaml
@@ -11,3 +11,5 @@ provideSandbox:
        
         - ["/lib32", "/lib32", [nofail]]
         - ["/lib64", "/lib64", [nofail]]
+    environment:
+        FOO: bar

--- a/test/sandbox/run.sh
+++ b/test/sandbox/run.sh
@@ -9,5 +9,5 @@ cleanup
 # Check if namespace feature works on this host.
 "${BOB_ROOT}/bin/bob-namespace-sandbox" -C || skip
 
-run_bob build root
+run_bob build -DFOO=bar root
 run_bob dev --sandbox -E root

--- a/test/show/config.yaml
+++ b/test/show/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.17.3.dev70"

--- a/test/show/recipes/dep.yaml
+++ b/test/show/recipes/dep.yaml
@@ -1,0 +1,2 @@
+packageScript: |
+    some dependency

--- a/test/show/recipes/root.yaml
+++ b/test/show/recipes/root.yaml
@@ -1,0 +1,48 @@
+root: True
+
+metaEnvironment:
+    META: a
+
+depends:
+    - name: sandbox
+      use: [sandbox]
+      forward: True
+    - name: tool
+      use: [tools, environment]
+      forward: True
+    - dep
+
+checkoutSCM:
+    - scm: cvs
+      dir: cvs
+      cvsroot: /foo
+      module: bar
+      rev: tag1
+    - scm: git
+      dir: git
+      url: git@git.test:foo/bar.git
+      commit: 0123456789abcdef0123456789abcdef01234567
+    - scm: import
+      dir: import
+      url: recipes
+    - scm: svn
+      dir: svn
+      url: https://svn.test/foo/bar
+      revision: 42
+    - scm: url
+      dir: url
+      url: ftp://url.test/foo/bar
+      digestSHA256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+checkoutDeterministic: True
+checkoutScript: |
+    true
+
+buildVars: [FOO, BAR]
+buildTools: [tool]
+buildScript: |
+    true
+
+packageVars: [META]
+packageScript: |
+    true

--- a/test/show/recipes/sandbox.yaml
+++ b/test/show/recipes/sandbox.yaml
@@ -1,0 +1,8 @@
+packageScript: |
+    some sandbox
+provideSandbox:
+    paths: ["/bin", "/usr/bin"]
+    mount:
+        - "/etc/resolv.conf"
+    environment:
+        AUTOCONF_BUILD: "x86_64-linux-gnu"

--- a/test/show/recipes/tool.yaml
+++ b/test/show/recipes/tool.yaml
@@ -1,0 +1,9 @@
+packageScript: |
+    some tool
+provideTools:
+    tool:
+        path: .
+        environment:
+            FOO: bar
+provideVars:
+    BAR: baz

--- a/test/show/run.sh
+++ b/test/show/run.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+
+# Smoke test to see if all output formats are not crashing
+run_bob show something-invalid
+run_bob show root --format=yaml --indent=2
+run_bob show root --format=json --no-indent
+run_bob show root --format=flat
+run_bob show "//*" --format=flat
+run_bob show --sandbox root/tool root/sandbox --format=diff
+
+# The diff format expects two packages. Otherwise it must fail
+expect_fail run_bob show root --format=diff
+
+# Normally common lines are suppressed in diff format. Can be enabled
+# selectively, though.
+run_bob show --format diff root/dep/ root/sandbox/ | expect_fail grep -q scriptLanguage
+run_bob show --format diff --show-common root/dep/ root/sandbox/ | grep -q scriptLanguage
+
+# Verify that empty properties are hidden by default but can be activated
+run_bob show root --no-indent | python3 -c '
+import sys, yaml
+d = yaml.load(sys.stdin.read())
+assert "checkoutTools" not in d
+'
+
+run_bob show root --show-empty | python3 -c '
+import sys, yaml
+d = yaml.load(sys.stdin.read())
+assert d["checkoutTools"] == {}
+'
+
+# Verify that filtering works as expected
+run_bob show root -f buildVars -f packageVars | python3 -c '
+import sys, yaml
+d = yaml.load(sys.stdin.read())
+assert set(d.keys()) == {"buildVars", "packageVars"}
+assert set(d["buildVars"].keys()) == {"FOO", "BAR"}
+assert set(d["packageVars"].keys()) == {"FOO", "BAR", "META"}
+'


### PR DESCRIPTION
The show command can be used to show all properties of a package as
they were computed by Bob when evaluating the recipes. The output can
be filtered and formatted in various ways. There is a special 'diff'
output format that produces a diff view of two packages.

- [x] Add documentation
- [x] Tests
