### PR TITLE
Add support for cloning a subset of submodules

### DIFF
--- a/doc/manpages/bob-status.rst
+++ b/doc/manpages/bob-status.rst
@@ -117,12 +117,16 @@ Status codes can be interpreted as follows:
 - ``O`` = overridden. This SCM is affected by a
   :ref:`configuration-config-scmOverrides`. Pass ``--show-overrides`` to force
   the output of a ``STATUS`` line if the SCM is otherwise unmodified.
-- ``S`` = switched. The commit/tag/branch/URL is different from the recipe.
+- ``S`` = switched. The commit/tag/branch/URL is different from the recipe. In
+  case of submodules the current commit is different from the one tracked in
+  the parent tree.
 - ``U`` = unpushed commits on configured branch. Git only. Some commits were made
   locally to the configured branch but they have not yet been pushed to the remote.
 - ``u`` = unpushed commits not on configured branch. Git only. There are commits
   on other local branches than the configured branch, on a possibly detached HEAD
-  or in the stash that have not been pushed to a remote.
+  or in the stash that have not been pushed to a remote. In case of shallowly
+  cloned submodules this might be shown incorrectly because there is not enough
+  information available about the remotes.
 
 The command shows the status of the current checkout. If the recipe was changed and
 the next build would move a checkout to the attic then the current information still

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -822,7 +822,7 @@ git    `Git`_ project               | ``url``: URL of remote repository
                                     | ``sslVerify``: Whether to verify the SSL certificate when fetching (optional)
                                     | ``shallow``: Number of commits or cutoff date that should be fetched (optional)
                                     | ``singleBranch``: Fetch only single branch instead of all (optional)
-                                    | ``submodules``: Whether to clone submodules. (optional)
+                                    | ``submodules``: Whether to clone all / a subset of submodules. (optional)
                                     | ``recurseSubmodules``: Recusively clone submodules (optional, defaults to false)
                                     | ``shallowSubmodules``: Clone submodules shallowly (optional, defaults to true)
 import Import directory from        | ``url``: Directory path relative to project root.
@@ -906,13 +906,18 @@ git
       history if ``shallow`` is used in the recipes.
 
    By default submodules will not be cloned. Set the ``submodules`` property to
-   true to populate them automatically. To recursively clone submodules of
+   true to populate them automatically. You can also set it to a list of paths
+   to clone only a subset of submodules. To recursively clone submodules of
    submodules too, set the ``recurseSubmodules`` property to ``True``::
 
       checkoutSCM:
           - scm: git
             url: foo@bar.test
             submodules: True           # clone all direct submodules
+          - scm: git
+            url: subset@foo.test
+            submodules:                # clone only submodule "foo/bar"
+               - foo/bar
           - scm: git
             url: something@else.test
             submodules: True           # clone submodules

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -23,6 +23,11 @@ import subprocess
 def normPath(p):
     return os.path.normcase(os.path.normpath(p))
 
+def dirIsEmpty(p):
+    if not os.path.isdir(p):
+        return False
+    return os.listdir(p) == []
+
 class GitScm(Scm):
 
     SCHEMA = schema.Schema({
@@ -560,6 +565,8 @@ class GitScm(Scm):
             if not os.path.exists(os.path.join(workspacePath, subPath, ".git")):
                 if shouldExist:
                     status.add(ScmTaint.modified, "> submodule not checked out: " + subPath)
+                elif not dirIsEmpty(os.path.join(workspacePath, subPath)):
+                    status.add(ScmTaint.modified, "> ignored submodule not empty: " + subPath)
                 continue
             elif not shouldExist:
                 status.add(ScmTaint.modified, "> submodule checked out: " + subPath)
@@ -735,6 +742,8 @@ class GitAudit(ScmAudit):
             if not os.path.exists(os.path.join(dir, subPath, ".git")):
                 if shouldExist:
                     return True # submodule is missing
+                elif not dirIsEmpty(os.path.join(dir, subPath)):
+                    return True # something in submodule which should not be there
                 else:
                     continue
             elif not shouldExist:

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -43,7 +43,7 @@ class GitScm(Scm):
         schema.Optional('sslVerify') : bool,
         schema.Optional('singleBranch') : bool,
         schema.Optional('shallow') : schema.Or(int, str),
-        schema.Optional('submodules') : bool,
+        schema.Optional('submodules') : schema.Or(bool, [str]),
         schema.Optional('recurseSubmodules') : bool,
         schema.Optional('shallowSubmodules') : bool,
     })
@@ -209,6 +209,9 @@ class GitScm(Scm):
             args += ["--depth", "1"]
         if self.__recurseSubmodules:
             args += ["--recursive"]
+        if isinstance(self.__submodules, list):
+            args.append("--")
+            args.extend(self.__submodules)
         await invoker.checkCommand(args, cwd=self.__dir)
 
     async def __updateSubmodulesPre(self, invoker, base = "."):
@@ -281,11 +284,14 @@ class GitScm(Scm):
         await invoker.checkCommand(args, cwd=self.__dir)
 
         # List all paths as per .gitmodules. This gives us the list of all
-        # known submodules.
+        # known submodules. Optionally restrict to user specified subset.
         args = [ "git", "-C", base, "config", "-f", ".gitmodules", "-z", "--get-regexp",
                  "path" ]
         allPaths = await invoker.checkOutputCommand(args, cwd=self.__dir)
         allPaths = [ p.split("\n")[1] for p in allPaths.split("\0") if p ]
+        if isinstance(self.__submodules, list):
+            subset = set(normPath(p) for p in self.__submodules)
+            allPaths = [ p for p in allPaths if normPath(p) in subset ]
 
         # Update only new or unmodified paths
         updatePaths = [ p for p in allPaths if oldState.get(normPath(p), True) ]
@@ -331,6 +337,8 @@ class GitScm(Scm):
 
         if self.__submodules:
             ret += " submodules"
+            if isinstance(self.__submodules, list):
+                ret += "[{}]".format(",".join(self.__submodules))
             if self.__recurseSubmodules:
                 ret += " recursive"
 
@@ -413,6 +421,7 @@ class GitScm(Scm):
                     ElementTree.SubElement(co, "timeout").text = str(timeout)
 
         if self.__submodules:
+            assert isinstance(self.__submodules, bool)
             sub = ElementTree.SubElement(extensions,
                     "hudson.plugins.git.extensions.impl.SubmoduleOption")
             if self.__recurseSubmodules:
@@ -436,7 +445,9 @@ class GitScm(Scm):
         return bool(self.__tag) or bool(self.__commit)
 
     def hasJenkinsPlugin(self):
-        return True
+        # Cloning a subset of submodules is not supported by the Jenkins
+        # git-plugin. Fall back to our implementation in this case.
+        return not isinstance(self.__submodules, list)
 
     def callGit(self, workspacePath, *args):
         cmdLine = ['git']
@@ -557,18 +568,27 @@ class GitScm(Scm):
                 if attribs.split(' ')[1] == "commit"
         }
 
+        # Normalize subset of submodules
+        if isinstance(shouldExist, list):
+            shouldExist = set(normPath(p) for p in shouldExist)
+        elif shouldExist:
+            shouldExist = set(normPath(p) for p in allPaths.keys())
+        else:
+            shouldExist = set()
+
         # Check each submodule for their commit, modifications and unpushed
         # stuff. Unconditionally recurse to even see if something is there even
         # tough it shouldn't.
         for path, commit in sorted(allPaths.items()):
             subPath = os.path.join(base, path)
+            subShouldExist = normPath(path) in shouldExist
             if not os.path.exists(os.path.join(workspacePath, subPath, ".git")):
-                if shouldExist:
+                if subShouldExist:
                     status.add(ScmTaint.modified, "> submodule not checked out: " + subPath)
                 elif not dirIsEmpty(os.path.join(workspacePath, subPath)):
                     status.add(ScmTaint.modified, "> ignored submodule not empty: " + subPath)
                 continue
-            elif not shouldExist:
+            elif not subShouldExist:
                 status.add(ScmTaint.modified, "> submodule checked out: " + subPath)
 
             realCommit = self.callGit(workspacePath, "-C", subPath, "rev-parse", "HEAD")
@@ -598,7 +618,7 @@ class GitScm(Scm):
     def getAuditSpec(self):
         extra = {}
         if self.__submodules:
-            extra['submodules'] = True
+            extra['submodules'] = self.__submodules
             if self.__recurseSubmodules:
                 extra['recurseSubmodules'] = True
         return ("git", self.__dir, extra)
@@ -684,7 +704,7 @@ class GitAudit(ScmAudit):
         'commit' : str,
         'description' : str,
         'dirty' : bool,
-        schema.Optional('submodules') : bool,
+        schema.Optional('submodules') : schema.Or(bool, [str]),
         schema.Optional('recurseSubmodules') : bool,
     })
 
@@ -734,19 +754,28 @@ class GitAudit(ScmAudit):
                 if attribs.split(' ')[1] == "commit"
         }
 
+        # Normalize subset of submodules
+        if isinstance(shouldExist, list):
+            shouldExist = set(normPath(p) for p in shouldExist)
+        elif shouldExist:
+            shouldExist = set(normPath(p) for p in allPaths.keys())
+        else:
+            shouldExist = set()
+
         # Check each submodule for their commit and modifications.
         # Unconditionally recurse to even see if something is there even tough
         # it shouldn't. Bail out on first modification.
         for path, commit in sorted(allPaths.items()):
             subPath = os.path.join(base, path)
+            subShouldExist = normPath(path) in shouldExist
             if not os.path.exists(os.path.join(dir, subPath, ".git")):
-                if shouldExist:
+                if subShouldExist:
                     return True # submodule is missing
                 elif not dirIsEmpty(os.path.join(dir, subPath)):
                     return True # something in submodule which should not be there
                 else:
                     continue
-            elif not shouldExist:
+            elif not subShouldExist:
                 # submodule checked out even though it shouldn't
                 return True
 
@@ -784,7 +813,7 @@ class GitAudit(ScmAudit):
             "dirty" : self.__dirty,
         }
         if self.__submodules:
-            ret["submodules"] = True
+            ret["submodules"] = self.__submodules
             if self.__recurseSubmodules:
                 ret["recurseSubmodules"] = True
         return ret

--- a/test/test_input_gitscm_status.py
+++ b/test/test_input_gitscm_status.py
@@ -262,6 +262,22 @@ class TestSubmodulesStatus(TestCase):
         self.assertTrue(status.dirty)
         self.assertTrue(audit["dirty"])
 
+    def testModifiedNotCloned(self):
+        """Test that modifications in not cloned submodules are detected"""
+        scm = self.createGitScm({'submodules':False})
+        self.invokeGit(scm)
+
+        cmd = """\
+            cd sub
+            echo created > some.txt
+        """
+        subprocess.check_call(cmd, shell=True, cwd=self.workspace)
+
+        status, audit = self.statusGitScm(scm)
+        self.assertEqual(status.flags, {ScmTaint.modified})
+        self.assertTrue(status.dirty)
+        self.assertTrue(audit["dirty"])
+
     def testModifiedSubSubModule(self):
         scm = self.createGitScm({'recurseSubmodules':True})
         self.invokeGit(scm)

--- a/test/test_input_gitscm_status.py
+++ b/test/test_input_gitscm_status.py
@@ -159,7 +159,7 @@ class TestSubmodulesStatus(TestCase):
         cls.repodir = cls.__repodir.name
 
         cmds = """\
-            mkdir -p main sub subsub
+            mkdir -p main sub subsub sub2
 
             # make sub-submodule
             cd subsub
@@ -183,6 +183,16 @@ class TestSubmodulesStatus(TestCase):
             git commit -m import
             cd ..
 
+            # setup second submodule
+            cd sub2
+            git init .
+            git config user.email "bob@bob.bob"
+            git config user.name test
+            echo sub2 > test.txt
+            git add test.txt
+            git commit -m import
+            cd ..
+
             # setup main module
             cd main
             git init .
@@ -191,6 +201,7 @@ class TestSubmodulesStatus(TestCase):
             echo main > test.txt
             git add test.txt
             git submodule add ../sub
+            git submodule add ../sub2
             git commit -m import
             cd ..
         """
@@ -385,6 +396,64 @@ class TestSubmodulesStatus(TestCase):
         cmd = """\
             cd sub
             git submodule update --init
+        """
+        subprocess.check_call(cmd, shell=True, cwd=self.workspace)
+
+        status, audit = self.statusGitScm(scm)
+        self.assertEqual(status.flags, {ScmTaint.modified})
+        self.assertTrue(status.dirty)
+        self.assertTrue(audit["dirty"])
+
+    def testSpecificUnmodified(self):
+        """Cloning a subset of submodules does not lead to dirty status"""
+        scm = self.createGitScm({'submodules' : ["sub2"]})
+        self.invokeGit(scm)
+        status, audit = self.statusGitScm(scm)
+
+        self.assertEqual(status.flags, set())
+        self.assertTrue(status.clean)
+        self.assertFalse(audit["dirty"])
+
+    def testSpecificModifiedSubmodule(self):
+        """Modifications are still detected if subset of submodules are cloned"""
+        scm = self.createGitScm({'submodules' : ["sub2"]})
+        self.invokeGit(scm)
+
+        cmd = """\
+            cd sub2
+            echo modified > test.txt
+        """
+        subprocess.check_call(cmd, shell=True, cwd=self.workspace)
+
+        status, audit = self.statusGitScm(scm)
+        self.assertEqual(status.flags, {ScmTaint.modified})
+        self.assertTrue(status.dirty)
+        self.assertTrue(audit["dirty"])
+
+    def testSpecificModifiedUnrelated(self):
+        """Test modifications in not checked out submodule are detected"""
+        scm = self.createGitScm({'submodules' : ["sub2"]})
+        self.invokeGit(scm)
+
+        cmd = """\
+            cd sub
+            echo created > some.txt
+        """
+        subprocess.check_call(cmd, shell=True, cwd=self.workspace)
+
+        status, audit = self.statusGitScm(scm)
+        self.assertEqual(status.flags, {ScmTaint.modified})
+        self.assertTrue(status.dirty)
+        self.assertTrue(audit["dirty"])
+
+    def testSpecificUnexpectedSubmodule(self):
+        """Detect populated submodule when it was ignored"""
+
+        scm = self.createGitScm({'submodules':["sub2"]})
+        self.invokeGit(scm)
+
+        cmd = """\
+            git submodule update --init sub
         """
         subprocess.check_call(cmd, shell=True, cwd=self.workspace)
 


### PR DESCRIPTION
Instead of cloning all submodules it is possible to give a list of paths
to the "submodules" property. Only these submodules will be cloned and
all others will be left uninitialized. This is not possible for
sub-submodules.

@rhubert Is this sufficient for your use case?