### PR TITLE
SCM inline switch support

### DIFF
--- a/pym/bob/scm/__init__.py
+++ b/pym/bob/scm/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..errors import ParseError
-from .scm import Scm, ScmStatus, ScmTaint, ScmOverride
+from .scm import Scm, ScmStatus, ScmTaint, ScmOverride, SYNTHETIC_SCM_PROPS
 from .cvs import CvsScm
 from .git import GitScm, GitAudit
 from .imp import ImportScm, ImportAudit
@@ -12,8 +12,6 @@ from .svn import SvnScm, SvnAudit
 from .url import UrlScm, UrlAudit
 import os.path
 import schema
-
-SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe', 'overridden'))
 
 async def auditFromDir(dir):
     if os.path.isdir(os.path.join(dir, ".git")):

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -11,6 +11,8 @@ from shlex import quote
 import fnmatch
 import re
 
+SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe', 'overridden'))
+
 class ScmOverride:
     def __init__(self, override):
         self.__match = override.get("match", {})
@@ -217,7 +219,7 @@ class Scm(metaclass=ABCMeta):
         return self.__source
 
     def getProperties(self, isJenkins):
-        # XXX: keep in sync with bob.scm.SYNTHETIC_SCM_PROPS
+        # XXX: keep in sync with SYNTHETIC_SCM_PROPS
         return {
             "__source" : self.__source,
             "recipe" : self.__recipe,

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -215,6 +215,17 @@ class Scm(metaclass=ABCMeta):
         self.__recipe = spec["recipe"]
         self.__overrides = overrides
 
+    def _diffSpec(self, oldSpec):
+        newSpec = self.getProperties(False)
+        ret = set()
+        for k in sorted(set(oldSpec.keys()) | set(newSpec.keys())):
+            if oldSpec.get(k) != newSpec.get(k):
+                ret.add(k)
+
+        ret -= SYNTHETIC_SCM_PROPS
+        ret -= {"if"}
+        return ret
+
     def getSource(self):
         return self.__source
 
@@ -234,6 +245,28 @@ class Scm(metaclass=ABCMeta):
         configured for the right workspace and will do the logging, error
         handling and so on...
         """
+
+    def canSwitch(self, oldSpec):
+        """Determine if an inline switch of a checkout from oldSpec is
+        possible.
+
+        The judgement is purely done on the specification of this SCM and
+        oldSpec. If the SCM supports a switch from oldSpec then this method
+        may return True. It must return False in any other case. In case it
+        returns True the Scm.switch() method will be invoked to do the acutal
+        switch in the workspace. This might still fail if the workspace is in
+        an unexpected state.
+        """
+        return False
+
+    async def switch(self, workspacePath, oldSpec):
+        """Try to switch the checkout in the workspace from oldSpec.
+
+        If the switch succeeds then the checkout won't be moved to the attic.
+        The SCM has to make sure that the result is the same as if the SCM was
+        moved to the attic and a fresh checkout would have been done.
+        """
+        return False
 
     @abstractmethod
     def asDigestScript(self):

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -252,6 +252,21 @@ class UrlScm(Scm):
 
         return None
 
+    def canSwitch(self, oldSpec):
+        diff = self._diffSpec(oldSpec)
+
+        # Filter irrelevant properties
+        diff -= {"sslVerify"}
+
+        # Adding, changing or removing hash sums is ok as long as the url stays
+        # the same.
+        return diff.issubset({"digestSHA1", "digestSHA256"})
+
+    async def switch(self, invoker, oldSpec):
+        # The real work is done in invoke() below. It will fail if the file
+        # does not match.
+        return True
+
     async def invoke(self, invoker):
         os.makedirs(invoker.joinPath(self.__dir), exist_ok=True)
         workspaceFile = os.path.join(self.__dir, self.__fn)

--- a/test/git-scm-switch/config.yaml
+++ b/test/git-scm-switch/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.17.3.dev82"

--- a/test/git-scm-switch/recipes/root.yaml
+++ b/test/git-scm-switch/recipes/root.yaml
@@ -1,0 +1,9 @@
+root: True
+
+checkoutSCM:
+    scm: git
+    url: file://${SCM_DIR}
+    rev: ${SCM_REV}
+
+buildScript: "true"
+packageScript: "true"

--- a/test/git-scm-switch/run.sh
+++ b/test/git-scm-switch/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash -e
+#
+# Check the various inline upgrade options of git. Will also provoke failures
+# to verify that the attic mode is still triggered.
+#
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+
+git_dir1=$(mktemp -d)
+git_dir2=$(mktemp -d)
+trap 'rm -rf "$git_dir1" "$git_dir2"' EXIT
+cleanup
+
+# Prepare git repositories
+
+pushd "$git_dir1"
+git init .
+git config user.email "bob@bob.bob"
+git config user.name test
+echo "hello world" > test.txt
+git add test.txt
+git commit -m "first commit"
+git tag -a -m "First Tag" tag1
+git checkout -b foobar
+d1_c1=$(git rev-parse HEAD)
+echo "changed" > test.txt
+git commit -a -m "second commit"
+git tag -a -m "Second Tag" tag2
+d1_c2=$(git rev-parse HEAD)
+popd
+
+pushd "$git_dir2"
+git init .
+git config user.email "bob@bob.bob"
+git config user.name test
+echo "hello bob" > bob.txt
+git add bob.txt
+git commit -m "first commit"
+d2_c1=$(git rev-parse HEAD)
+popd
+
+
+# First a simple checkout. We put a canary there to detect attic moves.
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="refs/heads/master" root
+expect_output "hello world" cat dev/src/root/1/workspace/test.txt
+echo canary > dev/src/root/1/workspace/canary.txt
+
+# Change branch
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="refs/heads/foobar" root
+expect_output "changed" cat dev/src/root/1/workspace/test.txt
+expect_exist dev/src/root/1/workspace/canary.txt
+
+# Change back
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="refs/heads/master" root
+expect_output "hello world" cat dev/src/root/1/workspace/test.txt
+expect_exist dev/src/root/1/workspace/canary.txt
+
+# Change repository but keep branch. This must move the dir into the attic
+# because they do not share a common history and the branch cannot be
+# forwarded.
+run_bob dev -DSCM_DIR="$git_dir2" -DSCM_REV="refs/heads/master" root -j
+expect_not_exist dev/src/root/1/workspace/test.txt
+expect_output "hello bob" cat dev/src/root/1/workspace/bob.txt
+expect_not_exist dev/src/root/1/workspace/canary.txt
+expect_exist dev/src/root/1/workspace/bob.txt
+
+# Revert back to 1st repository and checkout tag. This should succeed as inline
+# upgrade because this is always a hard checkout.
+echo canary > dev/src/root/1/workspace/canary.txt
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="refs/tags/tag2" root
+expect_output "changed" cat dev/src/root/1/workspace/test.txt
+expect_not_exist dev/src/root/1/workspace/bob.txt
+expect_exist dev/src/root/1/workspace/canary.txt
+
+# Enabling submodules is ok
+run_bob dev -c submodules -DSCM_DIR="$git_dir1" -DSCM_REV="refs/tags/tag2" root
+expect_exist dev/src/root/1/workspace/canary.txt
+
+# But disabling submodules must trigger an attic move
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="refs/tags/tag2" root
+expect_not_exist dev/src/root/1/workspace/canary.txt
+
+# Trying to trigger an inline upgrade for dirty data will fail and move to attic.
+echo canary > dev/src/root/1/workspace/canary.txt
+echo taint > dev/src/root/1/workspace/test.txt
+expect_exist dev/src/root/1/workspace/canary.txt
+run_bob dev -DSCM_DIR="$git_dir1" -DSCM_REV="$d1_c1" root
+expect_not_exist dev/src/root/1/workspace/canary.txt
+expect_output "hello world" cat dev/src/root/1/workspace/test.txt

--- a/test/git-scm-switch/submodules.yaml
+++ b/test/git-scm-switch/submodules.yaml
@@ -1,0 +1,5 @@
+scmOverrides:
+    - match:
+        scm: git
+      set:
+        submodules: True

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -168,7 +168,9 @@ if [[ -n "$RUN_UNITTEST_PAT" ]] ; then
 		fi
 	done
 
-	if type -p parallel >/dev/null && [[ ${RUN_JOBS:-} != 1 ]] ; then
+	if [[ ${#RUN_TEST_NAMES[@]} -eq 0 ]] ; then
+		: # No tests matched
+	elif type -p parallel >/dev/null && [[ ${RUN_JOBS:-} != 1 ]] ; then
 		export -f run_unit_test
 		export RUN_PYTHON3
 		parallel ${RUN_JOBS:+-j $RUN_JOBS} run_unit_test ::: "${RUN_TEST_NAMES[@]}"
@@ -193,7 +195,9 @@ if [[ -n "$RUN_BLACKBOX_PAT" ]] ; then
 		fi
 	done
 
-	if type -p parallel >/dev/null && [[ ${RUN_JOBS:-} != 1 ]] ; then
+	if [[ ${#RUN_TEST_NAMES[@]} -eq 0 ]] ; then
+		: # No tests matched
+	elif type -p parallel >/dev/null && [[ ${RUN_JOBS:-} != 1 ]] ; then
 		export -f run_blackbox_test
 		export RUN_PYTHON3
 		parallel ${RUN_JOBS:+-j $RUN_JOBS} run_blackbox_test ::: "${RUN_TEST_NAMES[@]}"

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -90,6 +90,16 @@ expect_exist()
 	return 0
 }
 
+expect_not_exist()
+{
+	if [[ -e "$1" ]] ; then
+		echo "Unexpected file: $1" >&2
+		return 1
+	fi
+
+	return 0
+}
+
 skip()
 {
 	exit 240

--- a/test/url-scm-switch/config.yaml
+++ b/test/url-scm-switch/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.17.3.dev82"

--- a/test/url-scm-switch/correct-sha1-sha256.yaml
+++ b/test/url-scm-switch/correct-sha1-sha256.yaml
@@ -1,0 +1,6 @@
+scmOverrides:
+    - match:
+        scm: url
+      set:
+        digestSHA1: d7dff2b1ef48b9c20c23d7b3a08b557957cec3c9
+        digestSHA256: f02d5a72cd2d57fa802840a76b44c6c6920a8b8e6b90b20e26c03876275069e0

--- a/test/url-scm-switch/correct-sha1.yaml
+++ b/test/url-scm-switch/correct-sha1.yaml
@@ -1,0 +1,5 @@
+scmOverrides:
+    - match:
+        scm: url
+      set:
+        digestSHA1: d7dff2b1ef48b9c20c23d7b3a08b557957cec3c9

--- a/test/url-scm-switch/file.txt
+++ b/test/url-scm-switch/file.txt
@@ -1,0 +1,1 @@
+This is a file.

--- a/test/url-scm-switch/file2.txt
+++ b/test/url-scm-switch/file2.txt
@@ -1,0 +1,1 @@
+This is another file.

--- a/test/url-scm-switch/incorrect-sha1.yaml
+++ b/test/url-scm-switch/incorrect-sha1.yaml
@@ -1,0 +1,5 @@
+scmOverrides:
+    - match:
+        scm: url
+      set:
+        digestSHA1: efed3690ea2243f5f1ac77cbb0987e5335440258

--- a/test/url-scm-switch/recipes/root.yaml
+++ b/test/url-scm-switch/recipes/root.yaml
@@ -1,0 +1,8 @@
+root: true
+
+checkoutSCM:
+  - scm: url
+    url: ${URL}
+
+buildScript: "true"
+packageScript: "true"

--- a/test/url-scm-switch/run.sh
+++ b/test/url-scm-switch/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+#
+# Verify that digests can be added/removed/modified without re-downloading a
+# file.
+#
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+url="$(realpath file.txt)"
+url2="$(realpath file2.txt)"
+
+# Build and fetch result path
+run_bob dev root -DURL="$url"
+path=$(run_bob query-path -DURL="$url" -f {src} root)
+
+# Add wrong sha1sum. Will fail build but the workspace is not moved to attic.
+echo "canary" > "$path/canary.txt"
+expect_fail run_bob dev root -DURL="$url" -c incorrect-sha1
+expect_exist  "$path/file.txt"
+expect_exist  "$path/canary.txt"
+
+# Moving to right sha1sum makes the build succeed and keeps the workspace intact
+run_bob dev root -DURL="$url" -c correct-sha1
+expect_exist  "$path/canary.txt"
+
+# Adding sha256 makes no difference
+run_bob dev root -DURL="$url" -c correct-sha1-sha256
+expect_exist  "$path/canary.txt"
+
+# Removing hash sums is a no-op
+run_bob dev root -DURL="$url"
+expect_exist  "$path/canary.txt"
+
+# Changing the URL will move old workspace to attic
+run_bob dev root -DURL="$url2"
+expect_not_exist  "$path/file.txt"
+expect_not_exist  "$path/canary.txt"
+diff -q "$path/file2.txt" file2.txt


### PR DESCRIPTION
Add support for git and url SCMs to change certain properties without doing a clean checkout. The following changes are supported:

* git: changing commit/tag/branch and url
* url: changing the hash sums

If the inline upgrade fails the SCM will still moved to the attic and a clean checkout is done.

Fixes #346.