### PR TITLE
builder: add option to force download of deps in different layers

### DIFF
--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -122,10 +122,12 @@ __bob_cook()
       __bob_complete_dir "$cur"
    elif [[ "$prev" = "--download" ]] ; then
          __bob_complete_words "yes no deps forced forced-deps forced-fallback"
+   elif [[ "$prev" = "--download-layer" ]] ; then
+         __bob_complete_words "yes= no= forced="
    elif [[ "$prev" = "--always-checkout" ]] ; then
       COMPREPLY=( )
    else
-      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E --upload --download --sandbox --no-sandbox --clean-checkout --no-link-deps --link-deps"
+      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E --upload --download --download-layer --sandbox --no-sandbox --clean-checkout --no-link-deps --link-deps"
    fi
 }
 

--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -14,8 +14,8 @@ Options
 
     This option will just make sure that the sources of matching packages are
     checked out. Bob will still try to find matching binary artifacts to skip
-    the actual compilation of these packages. See the ``--download`` option
-    to control what is built and what is downloaded.
+    the actual compilation of these packages. See the ``--download`` and
+    ``--download-layer`` option to control what is built and what is downloaded.
 
 ``--audit``
     Generate an audit trail when building.
@@ -73,6 +73,22 @@ Options
       forced-deps
     packages=<packages regex>
       download modules that match a given regular expression, build all other.
+
+``--download-layer MODE``
+    Download from binary archive for layer (yes, no, forced)
+
+    Acts like ``--download`` but only for the modules of the layer that match a
+    given regular expression (``--download`` option will be overwritten for
+    matching modules).
+    Can be used multiple times (if regex is used also multiple times the last mode wins).
+    A sub layer is separated with a ``/``.
+
+    no=<layer regex>
+      build modules of a layer that match a given regular expression from sources
+    yes=<layer regex>
+      download modules of a layer that match a given regular expression, if download fails - build it from sources
+    forced=<layer regex>
+      like 'yes' above, but fail if any download fails
 
 ``--incremental``
     Reuse build directory for incremental builds.
@@ -203,7 +219,7 @@ Options
     current workspace. Because of the pipe-usage many tools like gcc,
     ls, git detect they are not running on a tty and disable output
     coloring. Disable the logfile generation to get the colored output
-    back. 
+    back.
 
 ``-p, --with-provided``
     Build provided dependencies too. In combination with ``--destination`` this

--- a/doc/manpages/bob-build.rst
+++ b/doc/manpages/bob-build.rst
@@ -20,7 +20,7 @@ Synopsis
               [--clean | --incremental] [--always-checkout RE] [--resume]
               [-q] [-v] [--no-logfiles] [-D DEFINES] [-c CONFIGFILE]
               [-e NAME] [-E] [-M META] [--upload] [--link-deps]
-              [--no-link-deps] [--download MODE] [--sandbox | --no-sandbox]
+              [--no-link-deps] [--download MODE] [--download-layer MODE] [--sandbox | --no-sandbox]
               [--clean-checkout]
               PACKAGE [PACKAGE ...]
 

--- a/doc/manpages/bob-dev.rst
+++ b/doc/manpages/bob-dev.rst
@@ -20,8 +20,8 @@ Synopsis
             [--clean | --incremental] [--always-checkout RE] [--resume]
             [-q] [-v] [--no-logfiles] [-D DEFINES] [-c CONFIGFILE]
             [-e NAME] [-E] [-M META] [--upload] [--link-deps]
-            [--no-link-deps] [--download MODE] [--sandbox | --no-sandbox]
-            [--clean-checkout]
+            [--no-link-deps] [--download MODE] [--download-layer MODE]
+            [--sandbox | --no-sandbox] [--clean-checkout]
             PACKAGE [PACKAGE ...]
 
 Description

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -53,7 +53,7 @@ layer has the same structure as shown above but is merged with the other layers
 during parsing. This structure is recursive (a layer may contain another layer)
 but is flattened during parsing. A typical structure might look like the
 following::
- 
+
     .
     ├── classes
     │   └── ...
@@ -2146,6 +2146,8 @@ destination     ``--destination``      String (Path)
 download        ``--download``         String (``yes``, ``no``, ``deps``, ``forced``,
                                        ``forced-deps``, ``forced-fallback`` or
                                        ``packages=<packages>``)
+download-layer  ``--download-layer``   String (``yes=<layer>``, ``no=<layer>``,
+                                       ``forced=<layer>)
 force           ``-f``                 Boolean
 link_deps       ``--[no-]link-deps``   Boolean
 no_deps         ``-n``                 Boolean
@@ -2208,7 +2210,7 @@ preBuildHook
 
     If the hook returns with a non-zero status the build will be interrupted.
 
-postBuildHook 
+postBuildHook
     The post-build hook is run after a local build finished, regardless if the
     build succeeded or failed. It receives the status as first argument
     (``success`` or ``fail``) and the relative paths to the workspaces of the

--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -37,6 +37,10 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         if arg.startswith('packages=') or arg in ['yes', 'no', 'deps', 'forced', 'forced-deps', 'forced-fallback']:
             return arg
         raise argparse.ArgumentTypeError("{} invalid.".format(arg))
+    def _downloadLayerArgument(arg):
+        if re.match('^(yes|no|forced)=\S+$', arg):
+            return arg
+        raise argparse.ArgumentTypeError("{} invalid.".format(arg))
 
     parser.add_argument('packages', metavar='PACKAGE', type=str, nargs='+',
         help="(Sub-)package to build")
@@ -105,8 +109,11 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
     parser.add_argument('--no-link-deps', default=None, help="Do not add linked dependencies to workspace paths",
         dest='link_deps', action='store_false')
     parser.add_argument('--download', metavar="MODE", default=None,
-        help="Download from binary archive (yes, no, deps, forced, forced-deps, forced-fallback, packages=<packages>",
+        help="Download from binary archive (yes, no, deps, forced, forced-deps, forced-fallback, packages=<packages>)",
         type=_downloadArgument)
+    parser.add_argument('--download-layer', metavar="MODE", action='append', default=[],
+        help="Download from binary archive for layer recipes (yes=<layer>, no=<layer>, forced=<layer>)",
+        type=_downloadLayerArgument)
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=None,
         help="Enable sandboxing")
@@ -204,6 +211,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         builder.setArchiveHandler(getArchiver(recipes))
         builder.setUploadMode(args.upload)
         builder.setDownloadMode(args.download)
+        builder.setDownloadLayerMode(args.download_layer)
         builder.setCleanCheckout(args.clean_checkout)
         builder.setAlwaysCheckout(args.always_checkout + cfg.get('always_checkout', []))
         builder.setLinkDependencies(args.link_deps)

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2144,6 +2144,7 @@ class Recipe(object):
         }
         self.__corePackagesByMatch = []
         self.__corePackagesById = {}
+        self.__layer = layer
 
         sourceName = ("Recipe " if isRecipe else "Class  ") + packageName + (
             ", layer "+"/".join(layer) if layer else "")
@@ -2191,6 +2192,9 @@ class Recipe(object):
             visited.add(clsName)
 
         return ret
+
+    def getLayer(self):
+        return self.__layer
 
     def resolveClasses(self):
         # must be done only once

--- a/test/layer-download/.gitignore
+++ b/test/layer-download/.gitignore
@@ -1,0 +1,1 @@
+/default.yaml

--- a/test/layer-download/classes/dummy.yaml
+++ b/test/layer-download/classes/dummy.yaml
@@ -1,0 +1,6 @@
+buildVars: [BOB_RECIPE_NAME]
+buildScript: |
+   touch ${BOB_RECIPE_NAME#*::}.txt
+
+packageScript: |
+   cp -r $1/* .

--- a/test/layer-download/config.yaml
+++ b/test/layer-download/config.yaml
@@ -1,0 +1,5 @@
+bobMinimumVersion: "0.18"
+layers:
+    - componentA
+    - componentB
+

--- a/test/layer-download/layers/componentA/recipes/A/A.yaml
+++ b/test/layer-download/layers/componentA/recipes/A/A.yaml
@@ -1,0 +1,4 @@
+inherit: [dummy]
+
+depends:
+    - D::D

--- a/test/layer-download/layers/componentA/recipes/A/A2.yaml
+++ b/test/layer-download/layers/componentA/recipes/A/A2.yaml
@@ -1,0 +1,4 @@
+inherit: [dummy]
+
+depends:
+    - D::D

--- a/test/layer-download/layers/componentB/recipes/B/B.yaml
+++ b/test/layer-download/layers/componentB/recipes/B/B.yaml
@@ -1,0 +1,2 @@
+inherit: [dummy]
+

--- a/test/layer-download/recipes/C/C.yaml
+++ b/test/layer-download/recipes/C/C.yaml
@@ -1,0 +1,4 @@
+inherit: [dummy]
+
+depends:
+    - A::A2

--- a/test/layer-download/recipes/D/D.yaml
+++ b/test/layer-download/recipes/D/D.yaml
@@ -1,0 +1,1 @@
+inherit: [dummy]

--- a/test/layer-download/recipes/root.yaml
+++ b/test/layer-download/recipes/root.yaml
@@ -1,0 +1,15 @@
+root: True
+
+depends:
+   - A::A
+   - B::B
+   - C::C
+
+buildScript: |
+   rm -rf *
+   for i in "${!BOB_DEP_PATHS[@]}" ; do
+      cp -a ${BOB_DEP_PATHS[$i]}/* ./
+   done
+
+packageScript: |
+   cp -r $1/* .

--- a/test/layer-download/run.sh
+++ b/test/layer-download/run.sh
@@ -1,0 +1,103 @@
+#!/bin/bash -e
+. ../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+
+cleanup
+rm -rf default.yaml
+
+# setup local archive
+trap 'rm -rf "${archiveDir}"' EXIT
+archiveDir=$(mktemp -d)
+cat >default.yaml <<EOF
+archive:
+  -
+    backend: file
+    path: "$archiveDir"
+EOF
+
+function cleanArchive() {
+    rm -rf "${archiveDir}"
+    mkdir "${archiveDir}"
+}
+
+function checkBuildDirExist() {
+    [ $1 -eq 0 ] && expect_not_exist "work/A/A/build" || expect_exist "work/A/A/build"
+    [ $2 -eq 0 ] && expect_not_exist "work/B/B/build" || expect_exist "work/B/B/build"
+    [ $3 -eq 0 ] && expect_not_exist "work/C/C/build" || expect_exist "work/C/C/build"
+    [ $4 -eq 0 ] && expect_not_exist "work/D/D/build" || expect_exist "work/D/D/build"
+    [ $5 -eq 0 ] && expect_not_exist "work/A/A2/build" || expect_exist "work/A/A2/build"
+}
+
+function checkDistDirExist() {
+    [ $1 -eq 0 ] && expect_not_exist "work/A/A/dist" || expect_exist "work/A/A/dist"
+    [ $2 -eq 0 ] && expect_not_exist "work/B/B/dist" || expect_exist "work/B/B/dist"
+    [ $3 -eq 0 ] && expect_not_exist "work/C/C/dist" || expect_exist "work/C/C/dist"
+    [ $4 -eq 0 ] && expect_not_exist "work/D/D/dist" || expect_exist "work/D/D/dist"
+    [ $5 -eq 0 ] && expect_not_exist "work/A/A2/dist" || expect_exist "work/A/A2/dist"
+}
+
+# build and upload all
+run_bob build --download no --upload root
+
+# no download layer
+cleanup
+run_bob build --download deps root
+checkBuildDirExist 0 0 0 0 0
+checkDistDirExist 1 1 1 0 0
+
+# download deps
+cleanup
+run_bob build --download deps --download-layer no=componentA root
+checkBuildDirExist 1 0 0 0 0
+checkDistDirExist 1 1 1 1 0
+
+cleanup
+run_bob build --download deps --download-layer no=componentA --download-layer no=componentB root
+checkBuildDirExist 1 1 0 0 0
+checkDistDirExist 1 1 1 1 0
+
+cleanup
+run_bob build --download deps --download-layer no="component.*" root
+checkBuildDirExist 1 1 0 0 0
+checkDistDirExist 1 1 1 1 0
+
+# download yes
+cleanup
+run_bob build --download yes root/A::A
+checkBuildDirExist 0 0 0 0 0
+checkDistDirExist 1 0 0 0 0
+
+cleanup
+run_bob build --download yes --download-layer no=componentA root/A::A
+checkBuildDirExist 1 0 0 0 0
+checkDistDirExist 1 0 0 1 0
+
+cleanup
+run_bob build --download yes --download-layer no="component.*" root/A::A
+checkBuildDirExist 1 0 0 0 0
+checkDistDirExist 1 0 0 1 0
+
+# download no
+cleanup
+run_bob build --download no root
+checkBuildDirExist 1 1 1 1 1
+checkDistDirExist 1 1 1 1 1
+
+cleanup
+run_bob build --download no --download-layer yes=componentB root
+checkBuildDirExist 1 0 1 1 1
+checkDistDirExist 1 1 1 1 1
+
+# download forced and forced-deps
+cleanArchive
+cleanup
+run_bob build --download no root/B::B
+run_bob build --upload root
+
+cleanup
+expect_fail run_bob build --download forced root/B::B
+run_bob build --download forced --download-layer no=componentB root/B::B
+
+cleanup
+expect_fail run_bob build --download forced-deps root
+run_bob build --download forced-deps --download-layer no=componentB root
+


### PR DESCRIPTION
With --download=forced-deps-layers dependencies are forced to be
downloaded if they are in a different layer than the package
given on the command line.