### PR TITLE
input: fix graph cycles on weak tools

### DIFF
--- a/pym/bob/cmds/build/builder.py
+++ b/pym/bob/cmds/build/builder.py
@@ -1359,7 +1359,8 @@ cd {ROOT}
             if ret is None:
                 fingerprint = await self._getFingerprint(step, depth)
                 ret = await step.getDigestCoro(lambda x: self.__getBuildIdList(x, depth+1),
-                    True, fingerprint=fingerprint, platform=getPlatformTag())
+                    True, fingerprint=fingerprint, platform=getPlatformTag(),
+                    relaxTools=True)
                 self.__buildDistBuildIds[path] = ret
 
         return ret

--- a/pym/bob/cmds/jenkins.py
+++ b/pym/bob/cmds/jenkins.py
@@ -335,7 +335,8 @@ class JenkinsJob:
             fingerprint = self._fingerprintName(step)
             if fingerprint: fingerprint = "{sha1\n<" + fingerprint + "\n}"
             ret.extend(step.getDigest(lambda s: JenkinsJob._buildIdName(s), True,
-                SpecHasher, fingerprint=fingerprint, platform='p'))
+                SpecHasher, fingerprint=fingerprint, platform='p',
+                relaxTools=True))
 
         ret.append("EOF")
         return ret

--- a/test/test_input_recipeset.py
+++ b/test/test_input_recipeset.py
@@ -1070,7 +1070,11 @@ class TestToolsWeak(RecipesTmp, TestCase):
             """)
 
     def testWeak(self):
-        """Weak tools have no impact on package"""
+        """Weak tools have no impact on package build-id,
+
+        The variant-id is still affected to honestly reflect the build
+        structure of the recipes
+        """
         self.writeRecipe("r1", """\
             root: True
             depends:
@@ -1088,7 +1092,11 @@ class TestToolsWeak(RecipesTmp, TestCase):
         packages = self.generate()
         r1 = packages.walkPackagePath("r1").getPackageStep()
         r2 = packages.walkPackagePath("r2").getPackageStep()
-        self.assertEqual(r1.getVariantId(), r2.getVariantId())
+        def buildId(step):
+            # not the right definition but close enough for the test
+            return step.getDigest(buildId, relaxTools=True)
+        self.assertEqual(buildId(r1), buildId(r2))
+        self.assertNotEqual(r1.getVariantId(), r2.getVariantId())
         self.assertNotEqual(r1.getTools()["tool"].getStep().getVariantId(),
                             r2.getTools()["tool"].getStep().getVariantId())
 


### PR DESCRIPTION
With the introduction of weak tools the build graph could get cycles
where the recipes and their package description are actually cycle free.
This can happen because the variant-id of a used weak tool is actually
not significant, causing distinct nodes to be collapsed into a single
one. The build logic will then get stuck because it assumes that the
graph is acyclic.

To work around this problem the optimizations enabled by weak tools are
partially reverted. Weak tools are only considered for the build-id
calculation and now let the variant-id untouched. This restores the
build behaviour that was present before weak tools were introduced. But
for binary artifacts weak tools are still considered. This keeps
compatibility with previously built artifacts and will still match
artifacts if the weak tool changes.

The drawback is that changes to weakly used tools will lead to rebuilds
of all using packages. Because the build-id does consider weak tools
this will most likely immediately re-download the same package again.
This might be confusing to the user.

Fixes #387.