### PR TITLE
python-3.9 + msys: platform string "msys" renamed by "cygwin"

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -667,6 +667,7 @@ the variable list:
 
   * ``linux``: Linux
   * ``msys``: Windows/MSYS2
+  * ``cygwin``: Windows/Cygwin
   * ``win32``: Windows
   * ``darwin``: Mac OS X
 

--- a/pym/bob/generators/VisualStudio.py
+++ b/pym/bob/generators/VisualStudio.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .common import CommonIDEGenerator
-from ..utils import quoteCmdExe
+from ..utils import quoteCmdExe, isMsys
 from pathlib import Path, PureWindowsPath
 from shlex import quote as quoteBash
 from uuid import UUID
@@ -278,7 +278,7 @@ class Vs2019Generator(CommonIDEGenerator):
 
         # gather root paths
         bobPwd = Path(os.getcwd())
-        if sys.platform == 'msys':
+        if isMsys():
             if os.getenv('WD') is None:
                 raise BuildError("Cannot create Visual Studio project for Windows! MSYS2 must be started by msys2_shell.cmd script!")
             msysRoot = PureWindowsPath(os.getenv('WD')) / '..' / '..'
@@ -331,7 +331,7 @@ class Vs2019Generator(CommonIDEGenerator):
 
     def __generateBuildme(self, extra, projectRoot, bobRoot):
         buildMe = []
-        if sys.platform == 'msys':
+        if isMsys():
             extra = " ".join(quoteBash(e) for e in extra)
             buildMe.append("#!/bin/sh")
             buildMe.append("export PATH=" + quoteBash(os.environ["PATH"]))

--- a/pym/bob/generators/__init__.py
+++ b/pym/bob/generators/__init__.py
@@ -1,5 +1,6 @@
 from .EclipseCdtGenerator import eclipseCdtGenerator
 from .QtCreatorGenerator import qtProjectGenerator
+from ..utils import isWindows
 import sys
 
 __all__ = ['generators']
@@ -9,6 +10,6 @@ generators = {
     'qt-creator' : qtProjectGenerator,
 }
 
-if sys.platform == 'win32' or sys.platform == 'msys':
+if isWindows():
     from .VisualStudio import vs2019ProjectGenerator
     generators['vs2019'] = vs2019ProjectGenerator

--- a/pym/bob/generators/common.py
+++ b/pym/bob/generators/common.py
@@ -216,7 +216,7 @@ class CommonIDEGenerator:
             # find all executables
             if package.getPackageStep().isValid():
                 packageDir = package.getPackageStep().getWorkspacePath()
-                if sys.platform in ["msys", "win32"]:
+                if isWindows():
                     for root, directory, filenames in os.walk(packageDir):
                         for filename in filenames:
                             target = os.path.join(root, filename)

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -13,7 +13,7 @@ from .state import BobState
 from .stringparser import checkGlobList, Env, DEFAULT_STRING_FUNS, IfExpression
 from .tty import InfoOnce, Warn, WarnOnce, setColorMode
 from .utils import asHexStr, joinScripts, compareVersion, binStat, \
-    updateDicRecursive, hashString, getPlatformTag, isWindows
+    updateDicRecursive, hashString, getPlatformTag, isWindows, getPlatformString
 from itertools import chain
 from os.path import expanduser
 from string import Template
@@ -3434,7 +3434,7 @@ class RecipeSet:
         else:
             return schema.validate(default)
 
-    def parse(self, envOverrides={}, platform=sys.platform):
+    def parse(self, envOverrides={}, platform=getPlatformString()):
         if not os.path.isdir("recipes"):
             raise ParseError("No recipes directory found.")
         self.__cache.open()

--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -15,6 +15,7 @@ import shutil
 import stat
 import struct
 import sys
+import sysconfig
 
 def hashString(string):
     h = hashlib.md5()
@@ -178,6 +179,19 @@ def compareVersion(origLeft, origRight):
                             .format(origLeft, origRight))
     return ret
 
+
+def getPlatformString():
+    return __platformString
+
+def isMsys():
+    return __isMsys
+
+if sys.platform.startswith('msys') or sysconfig.get_platform().startswith('msys'):
+    __isMsys = True
+    __platformString = 'msys'
+else:
+    __isMsys = False
+    __platformString = sys.platform
 
 def isWindows():
     """Check if we run on a windows platform.
@@ -641,7 +655,7 @@ class EventLoopWrapper:
             origSigInt = signal.getsignal(signal.SIGINT)
             signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-            method = 'fork' if sys.platform == 'msys' else 'forkserver'
+            method = 'fork' if isWindows() else 'forkserver'
 
             # Hack to get coverage data with the multiprocessing module. Up to
             # date coverage.py cannot trace cross fork/exec. Taken and adapted


### PR DESCRIPTION
in MSYS2 with the update to python3.9 the platform string isn't "msys" anymore
the string is replaced by "cygwin".

we use isWindows or isMsys to check for the systems now.

.FIXES #416