### PR TITLE
ls: add option to show identical packages too

### DIFF
--- a/doc/manpages/bob-ls.rst
+++ b/doc/manpages/bob-ls.rst
@@ -13,8 +13,8 @@ Synopsis
 
 ::
 
-    bob ls [-h] [-a] [-o] [-r] [-u] [-p | -d] [-D DEFINES] [-c CONFIGFILE]
-           [--sandbox | --no-sandbox]
+    bob ls [-h] [-a] [-A] [-o] [-r] [-u] [-p | -d] [-D DEFINES]
+           [-c CONFIGFILE] [--sandbox | --no-sandbox]
            [package]
 
 
@@ -49,12 +49,21 @@ print the path of all *unique* packages that were selected by the query. This
 cannot be used in conjunction with the ``-p`` option and ignores further ``-a``,
 ``-o`` and ``-r`` options.
 
+To see *every* package selected by the query, add ``-A``. This will print all
+alternate paths to identical packages. This affects only the ``d`` and ``-p``
+options, because the path leading to the selected packages is significant.
+
 Options
 -------
 
 ``-a, --all``
     Show indirect dependencies too. By default only direct dependencies (i.e.
     dependencies explicitly specified in the recipe) are displayed.
+
+``-A, --alternates``
+    For listings that print the full path of packages (``-d``, ``-p``), display
+    all packages, including identical ones. By default only unique packages,
+    that were selected by the query, are displayed.
 
 ``-c CONFIGFILE``
     Use config File

--- a/pym/bob/cmds/misc.py
+++ b/pym/bob/cmds/misc.py
@@ -70,6 +70,8 @@ def doLS(argv, bobRoot):
                         help="Sub-package to start listing from")
     parser.add_argument('-a', '--all', default=False, action='store_true',
                         help="Show indirect dependencies too")
+    parser.add_argument('-A', '--alternates', default=False, action='store_true',
+                        help="Show all alternate paths to identical packages too")
     parser.add_argument('-o', '--origin', default=False, action='store_true',
                         help="Show origin of indirect dependencies")
     parser.add_argument('-r', '--recursive', default=False, action='store_true',
@@ -102,7 +104,8 @@ def doLS(argv, bobRoot):
     showAliases = packages.getAliases() if args.package == "" else []
 
     printer = PackagePrinter(args.all, args.origin, args.recursive, args.unsorted)
-    for (stack, root) in packages.queryTreePath(args.package):
+    showAlternates = args.alternates and (args.prefixed or args.direct)
+    for (stack, root) in packages.queryTreePath(args.package, showAlternates):
         if args.prefixed:
             printer.showPrefixed(root, showAliases, stack)
         elif args.direct:


### PR DESCRIPTION
By default only unique packages are displayed. The -A option shows all
identical packages too, instead of only the first one.

Fixes #338.