### PR TITLE
VisualStudio: fix generated files

### DIFF
--- a/pym/bob/generators/VisualStudio.py
+++ b/pym/bob/generators/VisualStudio.py
@@ -15,7 +15,6 @@ import os
 import sys
 
 SOLUTION_TEMPLATE = """\
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28803.352
@@ -42,8 +41,7 @@ SOLUTION_PROJECT_TEMPLATE = """\
 Project("{{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}}") = "{NAME}", "{NAME}\\{NAME}.vcxproj", "{{{GUID}}}"
 EndProject"""
 
-PROJECT_TEMPLATE = r"""\
-<?xml version="1.0" encoding="utf-8"?>
+PROJECT_TEMPLATE = r"""<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Build|Win32">


### PR DESCRIPTION
In commit 192d78f4 the project template was incorrectly adapted and now
had a backslash as file start. Similarly, the header of the solution
files had an empty line at the beginning.

Fixes #448.