### PR TITLE
generators: do not scan additional include dirs recursively

### DIFF
--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -89,7 +89,7 @@ passed on the command line *after* the package name.
     Packages will be marked as 'exclude from build' in eclipse. Usefull if indexer runs OOM.
 
 ``-I ADDITIONAL_INCLUDES``
-    Additional include directories. (added recursive starting from this directory)
+    Additional include directories.
 
 ``--name NAME``
     Name of project. Default is complete_path_to_package
@@ -138,7 +138,7 @@ to be passed on the command line *after* the package name.
     wtih foobar-* but excludes the foobar-baz package.
 
 ``-I ADDITIONAL_INCLUDES``
-    Additional include directories. (added recursive starting from this directory)
+    Additional include directories.
 
 ``--kit KIT``
     Name of the kit to use for this project.

--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -231,8 +231,7 @@ def eclipseCdtGenerator(package, argv, extra, bobRoot):
         # find additional include dirs
         for i in args.additional_includes:
             if os.path.exists(i):
-                for root, directories, filenames in os.walk(i):
-                    includeDirs.append(os.path.join(i,root))
+                includeDirs.append(i)
     except re.error as e:
         raise ParseError("Invalid regular expression '{}': {}".format(e.pattern), e)
 

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -301,8 +301,7 @@ def qtProjectGenerator(package, argv, extra, bobRoot):
     for i in args.additional_includes:
         for e in parseArgumentLine(i):
             if os.path.exists(e):
-                for root, directories, filenames in os.walk(e):
-                    hList.append(os.path.join(e,root))
+                hList.append(e)
 
     # compose start includes
     for i in args.start_includes:

--- a/pym/bob/generators/common.py
+++ b/pym/bob/generators/common.py
@@ -324,9 +324,7 @@ class CommonIDEGenerator:
         for i in self.args.additional_includes:
             for e in parseArgumentLine(i):
                 if os.path.exists(e):
-                    for root, directories, filenames in os.walk(e):
-                        filterDirs(directories)
-                        self.appendIncludeDirectories.append(os.path.join(e,root))
+                    self.appendIncludeDirectories.append(e)
 
     def generate(self):
         if self.args.overwrite:


### PR DESCRIPTION
Additional include directories are added last to the IDE search paths.
These directories were previously scanned recursively but the code to do
that was broken. Instead forward the paths literally to the IDE. If
multiple sub-directories need to be added the user can always give
another "-I" option.

Fixes #451.