### PR TITLE
input: cache sandbox when reconstructing graph

### DIFF
--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -508,7 +508,9 @@ class CoreRef:
         elif self.__diffSandbox in cache:
             sandbox = cache[self.__diffSandbox]
         else:
-            sandbox = self.__diffSandbox.refDeref(stack, inputTools, inputSandbox, pathFormatter, cache)
+            sandbox = self.__diffSandbox.refDeref(stack, inputTools, inputSandbox,
+                    pathFormatter, cache)
+            cache[self.__diffSandbox] = sandbox
 
         return self.__destination.refDeref(stack + self.__stackAdd, tools, sandbox, pathFormatter)
 


### PR DESCRIPTION
The CoreRef.refDeref() method needs to reconstruct the concrete
Step/Package from the reduced core graph. There is a cache to prevent
unneeded dereferencing of already seen edges. Unfortunately the cache
was not filled for sandbox references. Depending on the complexity of
the sandbox partial graph this could drastically increase the time to
traverse the graph.