### PR TITLE
mirrors for url scm

### DIFF
--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -374,8 +374,19 @@ class BuiltinSetting(PluginSetting):
 
 def Scm(spec, env, overrides, recipeSet):
     # resolve with environment
-    spec = { k : ( env.substitute(v, "checkoutSCM::"+k) if isinstance(v, str) else v)
-        for (k, v) in spec.items() }
+    for (k, v) in spec.items():
+        if isinstance(v, str):
+            spec[k] = env.substitute(v, "checkoutSCM::"+k)
+        elif isinstance(v, list):
+            spec[k] = []
+            for l in v:
+                x = env.substitute(l, "checkoutSCM::"+k)
+                if isinstance(x, list):
+                    spec[k].extend(x)
+                else:
+                    spec[k].append(x)
+        else:
+            spec[k] = v
 
     # apply overrides before creating scm instances. It's possible to switch the Scm type with an override..
     matchedOverrides = []

--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -211,7 +211,7 @@ class Scm(metaclass=ABCMeta):
     def __init__(self, spec, overrides):
         # Recipe foobar, checkoutSCM dir:., url:asdf
         self.__source = spec.get("__source", "<unknown>") + " in checkoutSCM: dir:" + \
-            spec.get("dir", ".") + ", url:" + spec.get("url", "?")
+            spec.get("dir", ".") + ", url:" + str(spec.get("url", "?"))
         self.__recipe = spec["recipe"]
         self.__overrides = overrides
 

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -8,6 +8,7 @@ from .tty import WarnOnce
 from .utils import infixBinaryOp
 from collections.abc import MutableMapping
 from types import MappingProxyType
+from ast import literal_eval
 import fnmatch
 import pyparsing
 import re
@@ -136,7 +137,11 @@ class StringParser:
             tok = self.nextToken(delim)
         else:
             if keep: self.index -= 1
-        return "".join(s)
+        # return a list of urls
+        if len(s) > 0 and isinstance(s[0], list):
+            return s[0]
+        else:
+            return "".join(s)
 
     def getVariable(self):
         # get variable name
@@ -619,6 +624,16 @@ def funMatchScm(args, **options):
 
     return "false"
 
+def funMirrors(args, **options):
+    if len(args) != 2: raise ParseError("mirrors expects two arguments")
+
+    mirrors = literal_eval(args[0])
+
+    return [v + args[1] for v in mirrors]
+
+def funList(args, **options):
+    return str(args)
+
 DEFAULT_STRING_FUNS = {
     "eq" : funEqual,
     "or" : funOr,
@@ -632,4 +647,6 @@ DEFAULT_STRING_FUNS = {
     "subst" : funSubst,
     "match" : funMatch,
     "matchScm" : funMatchScm,
+    "mirrors" : funMirrors,
+    "list" : funList,
 }


### PR DESCRIPTION
mirrors will be tried from top to bottom

examples:
```
checkoutSCM:
     scm: url
     url:
       - http://...
       - https://...
       - ftp://...
       - $(mirrors,$(list,http://...,https://...),/somewhere/archive.tar.gz)
```

or:
```
checkoutSCM:
     scm: url
     url: $(mirrors,$(list,http://...,https://...),/somewhere/archive.tar.gz)
```

it is possible to use a environment variable for the list:
```
checkoutSCM:
     scm: url
     url: $(mirrors,${MIRRORS},/somewhere/archive.tar.gz)
```

the variable can be defined e.g. in your default.yaml:
```
environment:
    MIRRORS: "$(list,http://...,https://...)"
```