### PR TITLE
utils: fix crash on large stat.st_ino fields

### DIFF
--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -536,7 +536,7 @@ def hashPath(path, index=None, ignoreDirs=None):
 
 def binStat(path):
     st = os.stat(path)
-    return struct.pack('=qqLqLQ', st.st_ctime_ns, st.st_mtime_ns,
+    return struct.pack('=qqLQLQ', st.st_ctime_ns, st.st_mtime_ns,
                        st.st_dev, st.st_ino, st.st_mode, st.st_size)
 
 


### PR DESCRIPTION
On Windows the stat.st_ino field is a 64-bit unsigned integer. The
DirHasher got this already correct but binStat() was using signed 64
bit which might overflow. POSIX also defines ino_t as unsigned integer type.

Fixes #464.