### PR TITLE
git: fix AttributeError in error message

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -250,7 +250,7 @@ class GitScm(Scm):
                     ok = await invoker.callCommand(fetchCmd + [self.__commit],
                         cwd=self.__dir)
                     if ok != 0:
-                        self.fail("Plain git-fetch in", self.__dir,
+                        invoker.fail("Plain git-fetch in", self.__dir,
                             "did not download the requested commit and the explicit fetch failed!",
                             returncode=ok)
             await invoker.checkCommand(["git", "checkout", "-q", "--no-recurse-submodules",

--- a/test/test_input_gitscm.py
+++ b/test/test_input_gitscm.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 
 from bob.input import GitScm
-from bob.invoker import Invoker, CmdFailedError
+from bob.invoker import Invoker, CmdFailedError, InvocationError
 from bob.errors import ParseError
 from bob.utils import asHexStr, runInEventLoop
 
@@ -465,6 +465,12 @@ class TestShallow(TestCase):
 
         return (len(log), branches)
 
+    def testShallowFail(self):
+        scm = self.createGitScm({ 'shallow' : 1,
+            'commit' : 'aabfa2e71de48ce8ed4dc51816572935593e6f04'})
+        with tempfile.TemporaryDirectory() as workspace:
+            with self.assertRaises(InvocationError):
+                commits, branches = self.invokeGit(workspace, scm)
 
     def testShallowNum(self):
         """Verify that shallow clones the right number of commits.


### PR DESCRIPTION
Fixes the following error:

     File "../pym/bob/scm/git.py", line 226, in invoke
       await self.__checkoutTag(invoker, fetchCmd, switch)
     File "../pym/bob/scm/git.py", line 253, in __checkoutTag
       self.fail("Plain git-fetch in", self.__dir,
     AttributeError: 'GitScm' object has no attribute 'fail'

raised if shallow clone is active and the commit can't be reached.
Also add some coverage for the failing line.