### PR TITLE
Fix spurious file renaming errors on Windows

### DIFF
--- a/pym/bob/generators/common.py
+++ b/pym/bob/generators/common.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..errors import BuildError
-from ..utils import removePath, isWindows, summonMagic
+from ..utils import removePath, isWindows, summonMagic, replacePath
 import argparse
 import os
 import re
@@ -346,7 +346,7 @@ class CommonIDEGenerator:
             oldContent = None
 
         if oldContent != newContent:
-            os.replace(newName, name)
+            replacePath(newName, name)
             with open(oldName, "wb") as f:
                 f.write(newContent)
         else:

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -13,7 +13,8 @@ from .state import BobState
 from .stringparser import checkGlobList, Env, DEFAULT_STRING_FUNS, IfExpression
 from .tty import InfoOnce, Warn, WarnOnce, setColorMode
 from .utils import asHexStr, joinScripts, compareVersion, binStat, \
-    updateDicRecursive, hashString, getPlatformTag, getPlatformString
+    updateDicRecursive, hashString, getPlatformTag, getPlatformString, \
+    replacePath
 from itertools import chain
 from os.path import expanduser
 from string import Template
@@ -3859,7 +3860,7 @@ class RecipeSet:
             with open(newCacheName, "wb") as f:
                 f.write(cacheKey)
                 PackagePickler(f, nameFormatter).dump(result)
-            os.replace(newCacheName, cacheName)
+            replacePath(newCacheName, cacheName)
         except OSError as e:
             print("Error saving internal state:", str(e), file=sys.stderr)
 

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -6,7 +6,8 @@
 from .. import BOB_VERSION
 from ..errors import BuildError, ParseError
 from ..stringparser import IfExpression
-from ..utils import asHexStr, hashFile, isWindows, removeUserFromUrl, sslNoVerifyContext
+from ..utils import asHexStr, hashFile, isWindows, removeUserFromUrl, sslNoVerifyContext, \
+        replacePath
 from .scm import Scm, ScmAudit
 from http.client import HTTPException
 import asyncio
@@ -252,7 +253,7 @@ class UrlScm(Scm):
                 # Atomically move file to destination. Set explicit mode to
                 # retain Bob 0.15 behaviour.
                 os.chmod(tmpFileName, stat.S_IREAD|stat.S_IWRITE)
-                os.replace(tmpFileName, destination)
+                replacePath(tmpFileName, destination)
                 tmpFileName = None
 
         except urllib.error.HTTPError as e:

--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -5,6 +5,7 @@
 
 from .errors import ParseError
 from .tty import colorize, WarnOnce, WARNING
+from .utils import replacePath
 import copy
 import errno
 import os
@@ -169,7 +170,7 @@ class _BobState():
                 with open(dirtyPath, "wb") as f:
                     with DigestAdder(f) as df:
                         pickle.dump(state, df)
-                os.replace(dirtyPath, self.__uncommittedPath)
+                replacePath(dirtyPath, self.__uncommittedPath)
             except OSError as e:
                 raise ParseError("Error saving workspace state: " + str(e))
         else:
@@ -188,7 +189,7 @@ class _BobState():
                     commit = (csum == data[-4:])
                 os.fsync(f.fileno())
             if commit:
-                os.replace(self.__uncommittedPath, self.__path)
+                replacePath(self.__uncommittedPath, self.__path)
                 return
             else:
                 print(colorize("Warning: discarding corrupted workspace state!", WARNING),


### PR DESCRIPTION
Replacing a file on Windows might fail spuriously. Add some mitigation that hopefully masks this transient errors...