### PR TITLE
git: handle encoding errors

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -587,7 +587,7 @@ class GitScm(Scm):
         cwd = os.path.join(workspacePath, self.__dir)
         try:
             output = subprocess.check_output(cmdLine, cwd=cwd,
-                universal_newlines=True, stderr=subprocess.DEVNULL)
+                universal_newlines=True, stderr=subprocess.DEVNULL, errors='replace')
         except subprocess.CalledProcessError as e:
             if check:
                 raise BuildError("git error:\n Directory: '{}'\n Command: '{}'\n'{}'".format(


### PR DESCRIPTION
Use the replacement error handling to avoid UnicodeDecodeErrors like
this:
```
An internal Exception has occured. This should not have happenend.
Please open an issue at https://github.com/BobBuildTool/bob with the following backtrace:
Bob version 0.20.1.dev12+g71b3cba
Traceback (most recent call last):
  File "bob/pym/bob/scripts.py", line 153, in catchErrors
    ret = fun(*args, **kwargs)
  File "bob/pym/bob/scripts.py", line 254, in cmd
    ret = cmd(args.args, bobRoot)
  File "bob/pym/bob/scripts.py", line 74, in __status
    doStatus(*args, **kwars)
  File "bob/pym/bob/cmds/build/status.py", line 300, in doStatus
    printer.showAllDirs(args.attic)
  File "bob/pym/bob/cmds/build/status.py", line 218, in showAllDirs
    status = getScm(scmSpec).status(workspace)
  File "bob/pym/bob/scm/git.py", line 689, in status
    *what)
  File "bob/pym/bob/scm/git.py", line 619, in callGit
    universal_newlines=True, stderr=subprocess.DEVNULL)
  File "/usr/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.7/subprocess.py", line 474, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.7/subprocess.py", line 926, in communicate
    stdout = self.stdout.read()
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe5 in position 553069: invalid continuation byte
```