### PR TITLE
spec: only add additional sandbox mounts from same package

### DIFF
--- a/pym/bob/languages.py
+++ b/pym/bob/languages.py
@@ -662,9 +662,13 @@ class StepSpec:
                 ],
             }
 
-            # special handling to mount all previous steps of current package
+            # Special handling to mount all previous steps of current package.
+            # It is defined that the checkout and build step are visible in the
+            # sandbox for a given package step. We must stop at checkout steps
+            # because they might have dependencies due to the 'checkoutDep'
+            # flag.
             extra = step
-            while extra.isValid() and len(extra.getArguments()) > 0:
+            while extra.isValid() and not extra.isCheckoutStep() and len(extra.getArguments()) > 0:
                 extra = extra.getArguments()[0]
                 if extra.isValid():
                     s['depMounts'].append((extra.getStoragePath(), extra.getExecPath(step)))


### PR DESCRIPTION
If a package is built in the sandbox it is defined that all previous
steps of the package are available in the sandbox. The code that added
these extra dependencies for the sandbox relied on the fact that
checkout steps have no dependencies. With the introduction of the
checkoutDep flag this is no longer the case. It is thus required to stop
iterating steps once we reached the checkout step.

Fixes #479.