### PR TITLE
RFC: archive: add plugin interface

### DIFF
--- a/contrib/plugins/artifactoryArchiveAccess.py
+++ b/contrib/plugins/artifactoryArchiveAccess.py
@@ -1,0 +1,73 @@
+from bob.archive_access import BaseArchiveAccess
+
+from artifactory import ArtifactoryPath
+import os
+import tempfile
+import datetime
+import calendar
+import struct
+
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class Artifactory(BaseArchiveAccess):
+    def __init__(self):
+        self.__url = "https://artifactory/bobs_cache"
+        print("Using Artifactory Archive @ " + self.__url)
+
+    def get(self, path):
+        out = tempfile.NamedTemporaryFile("wb", delete=False)
+        try:
+            archive = ArtifactoryPath(self.__url + path, verify=False)
+            with archive.open() as fd:
+                out.write(fd.read())
+
+        except Exception as e:
+            logging.error(traceback.format_exc())
+        out.close()
+        return out.name
+
+    def removeTmp(self, tmp):
+        # remove the tmp file
+        if tmp is not None and os.path.exists(tmp):
+            os.unlink(tmp)
+
+    def listdir(self, path):
+        if path != ".":
+            base = self.__url + path
+        else:
+            base = self.__url
+        if not base.endswith("/"):
+            base += "/"
+        self.__path = ArtifactoryPath(base, verify=False)
+        ret = [ str(p).replace(base, "") for p in self.__path ]
+        return ret
+
+    def binStat(self, path):
+        archive = ArtifactoryPath(self.__url + path, verify=False)
+        # Get FileStat
+        stat = archive.stat()
+        ctime = calendar.timegm(stat.ctime.timetuple())
+        mtime = calendar.timegm(stat.mtime.timetuple())
+        size = stat.size
+        archive = ArtifactoryPath(self.__url + path, verify=False)
+        return struct.pack('=qqQ64s', ctime, mtime, stat.size, bytes(stat.sha256, 'utf-8'))
+
+    def unlink(self, path):
+        archive = ArtifactoryPath(self.__url + path, verify=False)
+        if archive.exists():
+            archive.unlink()
+
+    def getSize(self,path):
+        archive = ArtifactoryPath(self.__url + path, verify=False)
+        if archive.exists():
+            return  archive.stat().size
+
+ArtifactoryAccess = Artifactory()
+
+manifest = {
+    'apiVersion' : "0.21",
+    'archiveAccessors' : {
+        'Artifactory' : ArtifactoryAccess
+    }
+}

--- a/pym/bob/archive_access.py
+++ b/pym/bob/archive_access.py
@@ -1,0 +1,22 @@
+class BaseArchiveAccess:
+    """Base class for Archive Access handlers.
+    """
+    def get(self, path):
+        """Get the package 'path' from the archive.
+        Return the path the a local accessable archive file."""
+        return ""
+    def removeTmp(self, path):
+        """Remove the temporary file returned by 'get'"""
+        return None
+    def listdir(self, path):
+        """Return a list of directory entries"""
+        return None
+    def getSize(self,path):
+        """Return the file size (in bytes) for 'path'"""
+        return None
+    def unlink(self, path):
+        """Unlink 'path' from archive"""
+        return None
+    def binStat(self, path):
+        """Return binary stat for 'path'"""
+        return None

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2897,6 +2897,7 @@ class RecipeSet:
         self.__scmOverrides = []
         self.__hooks = {}
         self.__projectGenerators = {}
+        self.__archiveAccessors = {}
         self.__configFiles = []
         self.__properties = {}
         self.__states = {}
@@ -3157,6 +3158,12 @@ class RecipeSet:
                 }
             self.__projectGenerators.update(projectGenerators)
 
+        archiveAccessors = manifest.get('archiveAccessors', {})
+        if not isinstance(archiveAccessors, dict):
+            raise ParseError("Plugin '"+fileName+"': 'archiveAccessor' has wrong type!")
+        if archiveAccessors:
+            self.__archiveAccessors.update(archiveAccessors)
+
         properties = manifest.get('properties', {})
         if not isinstance(properties, dict):
             raise ParseError("Plugin '"+fileName+"': 'properties' has wrong type!")
@@ -3224,6 +3231,9 @@ class RecipeSet:
 
     def setConfigFiles(self, configFiles):
         self.__configFiles = configFiles
+
+    def getArchiveAccessors (self):
+        return self.__archiveAccessors
 
     def getCommandConfig(self):
         return self.__commandConfig


### PR DESCRIPTION
Extend the archive command to clean up a non local archive using a
custom plugin. Therefore the plugin manifest must contain
'archiveAccessors'. Each entry should point to a class inheriting from
'BaseArchiveAccess' providing the appropriate methods to access the
custom archive.

Fixes #340.