### PR TITLE
stringparser: add get-tool-env function

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -392,6 +392,11 @@ The following built in string functions are supported:
   of ``text``.
 * ``$(subst,from,to,text)``: Replace every occurence of ``from`` with ``to`` in
   ``text``.
+* ``$(get-tool-env,tool,var[,default])``: Return the environment variable ``var``
+  defined by tool ``tool``. The substition will fail if the variable is
+  undefined in the tools :ref:`configuration-recipes-provideTools` environment
+  definition unless the optional ``default`` is given, which is then used
+  instead.
 
 The following built in string functions are additionally supported in
 :ref:`package path queries <manpage-bobpaths>`. They cannot be used in recipes

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -309,14 +309,17 @@ class FunctionCall():
         return "{}({})".format(self.name,
             ", ".join(str(a) for a in self.args))
 
-    def evalExpression(self, env):
+    def evalExpressionToString(self, env):
         extra = env.funArgs
         args = [ a.evalExpressionToString(env) for a in self.args ]
         if self.name not in env.funs:
             raise ParseError("Bad syntax: " + "Unknown string function: "\
                     + self.name)
         fun = env.funs[self.name]
-        return isTrue(fun(args, env=env, **extra))
+        return fun(args, env=env, **extra)
+
+    def evalExpression(self, env):
+        return isTrue(self.evalExpressionToString(env))
 
 class BinaryStrOperator():
     __slots__ = ('op', 'opStr', 'left', 'right')

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -598,6 +598,27 @@ def funToolDefined(args, __tools, **options):
     if len(args) != 1: raise ParseError("is-tool-defined expects one argument")
     return "true" if (args[0] in __tools) else "false"
 
+def funToolEnv(args, __tools, **options):
+    l = len(args)
+    if l == 2:
+        tool, var = args
+        default = None
+    elif l == 3:
+        tool, var, default = args
+    else:
+        raise ParseError("get-tool-env expects two or three arguments")
+
+    try:
+        env = __tools[tool].environment
+    except KeyError:
+        raise ParseError("get-tool-env: tool '{}' undefined".format(tool))
+
+    ret = env.get(var, default)
+    if ret is None:
+        raise ParseError("get-tool-env: undefined variable '{}' in tool '{}'".format(var, tool))
+
+    return ret
+
 def funMatchScm(args, **options):
     if len(args) != 2: raise ParseError("matchScm expects two arguments")
     name = args[0]
@@ -626,6 +647,7 @@ DEFAULT_STRING_FUNS = {
     "if-then-else" : funIfThenElse,
     "is-sandbox-enabled" : funSandboxEnabled,
     "is-tool-defined" : funToolDefined,
+    "get-tool-env" : funToolEnv,
     "ne" : funNotEqual,
     "not" : funNot,
     "strip" : funStrip,

--- a/test/unit/test_if_expression.py
+++ b/test/unit/test_if_expression.py
@@ -12,7 +12,11 @@ from bob.errors import BobError
 class TestIfExpressionParser(TestCase):
 
     def setUp(self):
-        tools = {"a":1, "b":2}
+        tool_a = MagicMock()
+        tool_a.environment = {}
+        tool_b = MagicMock()
+        tool_b.environment = { "foo" : "bar" }
+        tools = {"a" : tool_a, "b" : tool_b}
         self.__env = Env({"FOO" : "foo"
             })
         self.__env.setFuns(DEFAULT_STRING_FUNS.copy())
@@ -76,6 +80,11 @@ class TestIfExpressionParser(TestCase):
         self.assertFalse(self.evalExpr('is-tool-defined("c")'))
         self.assertFalse(self.evalExpr('match( "string", "pattern")'))
         self.assertRaises(BobError, self.evalExpr, "!does-not-exist()")
+
+    def testComplex(self):
+        self.assertTrue(self.evalExpr('get-tool-env("b", "foo") == "bar"'))
+        self.assertFalse(self.evalExpr('get-tool-env("a", "foo", "x") != "x"'))
+        self.assertTrue(self.evalExpr('!get-tool-env("a", "foo", "")'))
 
     def testCompare(self):
         """Equality comparison should work on the actual expression"""


### PR DESCRIPTION
Query defined variables of a tool. The tool must only be defined and is
not required to be used by the recipe.

Fixes #486.