### PR TITLE
Run selected checkoutScripts in build-only mode

### DIFF
--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -181,7 +181,9 @@ Options
    defined by Bob itself (e.g. ``meta.bob``) cannot be redifined!
 
 ``-b, --build-only``
-    Don't checkout, just build and package
+    Don't checkout, just build and package. Checkout scripts whose
+    :ref:`configuration-recipes-checkoutUpdateIf` property was evaluated as
+    true will still be run.
 
     If the sources of a package that needs to be built are missing then Bob
     will still check them out. This option just prevents updates of existing

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -966,7 +966,7 @@ git
    The ``rev`` property of the ``git`` SCM unifies the specification of the
    desired branch/tag/commit into one single property. If present it will be
    evaluated first. Any other ``branch``, ``tag`` or ``commit`` property is
-   evalued after it and may override a precious setting made by ``rev``. The
+   evaluated after it and may override a previous setting made by ``rev``. The
    branch/tag/commit precedence is still respected, though. Following the patterns
    described in git-rev-parse(1) the following formats are currently supported:
 

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1089,6 +1089,41 @@ url
        possible to fetch multiple files in the same directory. This is done to
        separate possibly extracted files safely from other checkouts.
 
+.. _configuration-recipes-checkoutUpdateIf:
+
+checkoutUpdateIf
+~~~~~~~~~~~~~~~~
+
+Type: String | Boolean | ``null`` | IfExpression
+(:ref:`configuration-principle-booleans`), default: ``False``
+
+By default no checkout scripts are run when building with ``--build-only``.
+Some use cases practically require the ``checkoutScript`` to be always run,
+through. A typical example are code generators that generate sources from some
+high level description. These generators must be run every time when the user
+has changed the input. A recipe or class can explicitly opt in to run their
+``checkoutScript`` also in build-only mode to cover such a use case. This is
+done by either setting ``checkoutUpdateIf`` to ``True`` or by a boolean
+expression that is evaluated to ``True``. Otherwise the ``checkoutScript`` is
+ignored even if some other class enables its script. The ``checkoutUpdateIf``
+property thus only applies to the corresponding ``checkoutScript`` in the same
+recipe/class.
+
+A ``null`` value has a special semantic. It does not enable the
+``checkoutScript`` on ``--build-only`` builds by itself but only if some
+inherited class or the recipe does enable its ``checkoutUpdateIf``. This is
+useful for classes to provide some update functions but, unless an inheriting
+recipe explicitly enables ``checkoutUpdateIf``, does not cause the checkout
+step to run by itself in ``--build-only`` mode.
+
+Examples::
+
+    checkoutUpdateIf: False                             # default, same as if unset
+    checkoutUpdateIf: True                              # unconditionally run checkoutScript
+    checkoutUpdateIf: "$(is-tool-defined,idl-compiler)" # boolean expression
+    checkoutUpdateIf: !expr |                           # IfExpression
+                        is-tool-defined("idl-compiler")
+
 .. _configuration-recipes-depends:
 
 depends

--- a/pym/bob/cmds/invoke.py
+++ b/pym/bob/cmds/invoke.py
@@ -15,8 +15,8 @@ def doInvoke(argv, bobRoot):
     parser = argparse.ArgumentParser(prog="bob _invoke",
         description="Invoke a single step.")
     parser.add_argument('spec', help="The step spec file")
-    parser.add_argument('mode', default='run', choices=['run', 'shell', 'fingerprint'], nargs='?',
-        help="Invocation mode")
+    parser.add_argument('mode', default='run', choices=['run', 'update', 'shell', 'fingerprint'],
+        nargs='?', help="Invocation mode")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--clean', '-c', action='store_true', default=False,
@@ -51,11 +51,12 @@ def doInvoke(argv, bobRoot):
                               False, executor=executor)
             ret = loop.run_until_complete(invoker.executeStep(InvocationMode.SHELL,
                 args.clean, args.keep_sandbox))
-        elif args.mode == 'run':
+        elif args.mode in ('run', 'update'):
             invoker = Invoker(spec, args.preserve_env, args.no_logfiles,
                 verbosity >= 2, verbosity >= 1, verbosity >= 3, False,
                 executor=executor)
-            ret = loop.run_until_complete(invoker.executeStep(InvocationMode.CALL,
+            ret = loop.run_until_complete(invoker.executeStep(
+                InvocationMode.CALL if args.mode == 'run' else InvocationMode.UPDATE,
                 args.clean, args.keep_sandbox))
         elif args.mode == 'fingerprint':
             invoker = Invoker(spec, args.preserve_env, True, True, True,

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -803,6 +803,9 @@ class CoreStep(CoreItem):
     def getDigestScript(self):
         raise NotImplementedError
 
+    def getUpdateScript(self):
+        return ""
+
     def getLabel(self):
         raise NotImplementedError
 
@@ -816,6 +819,9 @@ class CoreStep(CoreItem):
 
     def isDeterministic(self):
         return self.deterministic
+
+    def isUpdateDeterministic(self):
+        return True
 
     def isCheckoutStep(self):
         return False
@@ -1055,6 +1061,12 @@ class Step:
         """
         return self._coreStep.getDigestScript()
 
+    def getUpdateScript(self):
+        return self._coreStep.getUpdateScript()
+
+    def isUpdateDeterministic(self):
+        return self._coreStep.isUpdateDeterministic()
+
     def isDeterministic(self):
         """Return whether the step is deterministic.
 
@@ -1246,10 +1258,11 @@ class Step:
 
 
 class CoreCheckoutStep(CoreStep):
-    __slots__ = ( "scmList" )
+    __slots__ = ( "scmList", "__checkoutUpdateIf", "__checkoutUpdateDeterministic" )
 
     def __init__(self, corePackage, checkout=None, checkoutSCMs=[],
-                 fullEnv=Env(), digestEnv=Env(), env=Env(), args=[]):
+                 fullEnv=Env(), digestEnv=Env(), env=Env(), args=[],
+                 checkoutUpdateIf=[], checkoutUpdateDeterministic=True):
         if checkout:
             recipeSet = corePackage.recipe.getRecipeSet()
             overrides = recipeSet.scmOverrides()
@@ -1273,6 +1286,8 @@ class CoreCheckoutStep(CoreStep):
             isValid = False
             self.scmList = []
 
+        self.__checkoutUpdateIf = checkoutUpdateIf
+        self.__checkoutUpdateDeterministic = checkoutUpdateDeterministic
         deterministic = corePackage.recipe.checkoutDeterministic
         super().__init__(corePackage, isValid, deterministic, digestEnv, env, args)
 
@@ -1293,6 +1308,9 @@ class CoreCheckoutStep(CoreStep):
 
     def isDeterministic(self):
         return super().isDeterministic() and all(s.isDeterministic() for s in self.scmList)
+
+    def isUpdateDeterministic(self):
+        return self.__checkoutUpdateDeterministic
 
     def hasLiveBuildId(self):
         return super().isDeterministic() and all(s.hasLiveBuildId() for s in self.scmList)
@@ -1323,6 +1341,10 @@ class CoreCheckoutStep(CoreStep):
                     + [s.asDigestScript() for s in recipe.checkoutAsserts])
         else:
             return None
+
+    def getUpdateScript(self):
+        glue = getLanguage(self.corePackage.recipe.scriptLanguage.index).glue
+        return joinScripts(self.__checkoutUpdateIf, glue) or ""
 
     @property
     def fingerprintMask(self):
@@ -1493,8 +1515,10 @@ class CorePackage:
         tools, sandbox = self.internalRef.refDeref(stack, inputTools, inputSandbox, pathFormatter)
         return Package(self, stack, pathFormatter, inputTools, tools, inputSandbox, sandbox)
 
-    def createCoreCheckoutStep(self, checkout, checkoutSCMs, fullEnv, digestEnv, env, args):
-        ret = self.checkoutStep = CoreCheckoutStep(self, checkout, checkoutSCMs, fullEnv, digestEnv, env, args)
+    def createCoreCheckoutStep(self, checkout, checkoutSCMs, fullEnv, digestEnv,
+                               env, args, checkoutUpdateIf, checkoutUpdateDeterministic):
+        ret = self.checkoutStep = CoreCheckoutStep(self, checkout, checkoutSCMs,
+            fullEnv, digestEnv, env, args, checkoutUpdateIf, checkoutUpdateDeterministic)
         return ret
 
     def createInvalidCoreCheckoutStep(self):
@@ -1933,6 +1957,7 @@ class Recipe(object):
             "depends" : [
                 { "name" : name, "use" : ["result"] } for name in roots
             ],
+            "checkoutUpdateIf" : False,
             "buildScript" : "true",
             "packageScript" : "true"
         }
@@ -2015,6 +2040,7 @@ class Recipe(object):
         for a in self.__checkoutAsserts:
             a["__source"] = sourceName + ", checkoutAssert #{}".format(i)
             i += 1
+        self.__checkoutUpdateIf = recipe["checkoutUpdateIf"]
         self.__build = fetchScripts(recipe, "build", incHelperBash, incHelperPwsh)
         self.__package = fetchScripts(recipe, "package", incHelperBash, incHelperPwsh)
         self.__fingerprintScriptList = fetchFingerprintScripts(recipe)
@@ -2089,15 +2115,25 @@ class Recipe(object):
             if ret is not None:
                 return ret
             return r.__checkout[self.__scriptLanguage][1][0] is None
-        self.__checkoutDeterministic = all(coDet(i) for i in inheritAll)
+
+        checkoutDeterministic = [ coDet(i) for i in inheritAll ]
+        self.__checkoutDeterministic = all(checkoutDeterministic)
 
         # merge scripts and other lists
         selLang = lambda x: x[self.__scriptLanguage]
 
         # Join all scripts. The result is a tuple with (setupScript, mainScript, digestScript)
-        self.__checkout = mergeScripts([ selLang(i.__checkout) for i in inheritAll ], glue)
+        checkoutScripts = [ selLang(i.__checkout) for i in inheritAll ]
+        self.__checkout = mergeScripts(checkoutScripts, glue)
         self.__checkoutSCMs = list(chain.from_iterable(i.__checkoutSCMs for i in inheritAll))
         self.__checkoutAsserts = list(chain.from_iterable(i.__checkoutAsserts for i in inheritAll))
+        self.__checkoutUpdateIf = [
+            (cond, fragments[1][0], deterministic)
+                for cond, fragments, deterministic
+                in zip((i.__checkoutUpdateIf for i in inheritAll), checkoutScripts,
+                       checkoutDeterministic)
+                if cond != False
+        ]
         self.__build = mergeScripts([ selLang(i.__build) for i in inheritAll ], glue)
         self.__package = mergeScripts([ selLang(i.__package) for i in inheritAll ], glue)
         self.__fingerprintScriptList = [ i.__fingerprintScriptList for i in inheritAll ]
@@ -2511,9 +2547,24 @@ class Recipe(object):
             checkoutDigestEnv = env.prune(self.__checkoutVars)
             checkoutEnv = ( env.prune(self.__checkoutVars | self.__checkoutVarsWeak)
                 if self.__checkoutVarsWeak else checkoutDigestEnv )
+            checkoutUpdateIf = [
+                ( (env.evaluate(cond, "checkoutUpdateIf")
+                    if (isinstance(cond, str) or isinstance(cond, IfExpression))
+                    else cond),
+                  script,
+                  deterministic)
+                for cond, script, deterministic in self.__checkoutUpdateIf ]
+            if any(cond == True for cond, _, _ in checkoutUpdateIf):
+                checkoutUpdateDeterministic = all(
+                    deterministic for cond, _, deterministic in checkoutUpdateIf
+                    if cond != False)
+                checkoutUpdateIf = [ script for cond, script, _ in checkoutUpdateIf if cond != False ]
+            else:
+                checkoutUpdateDeterministic = True
+                checkoutUpdateIf = []
             srcCoreStep = p.createCoreCheckoutStep(self.__checkout,
                 self.__checkoutSCMs, env, checkoutDigestEnv, checkoutEnv,
-                checkoutDeps)
+                checkoutDeps, checkoutUpdateIf, checkoutUpdateDeterministic)
         else:
             srcCoreStep = p.createInvalidCoreCheckoutStep()
 
@@ -3560,6 +3611,7 @@ class RecipeSet:
             schema.Optional('checkoutSetup') : str,
             schema.Optional('checkoutSetupBash') : str,
             schema.Optional('checkoutSetupPwsh') : str,
+            schema.Optional('checkoutUpdateIf', default=False) : schema.Or(None, str, bool, IfExpression),
             schema.Optional('buildScript') : str,
             schema.Optional('buildScriptBash') : str,
             schema.Optional('buildScriptPwsh') : str,

--- a/pym/bob/languages.py
+++ b/pym/bob/languages.py
@@ -542,7 +542,7 @@ class PwshLanguage:
                     $ret["Env"][$i.Name] = $i.Value
                 }}
                 $ret["Vars"].Remove("ret")
-                [System.IO.File]::WriteAllLines({ENV_FILE}, (ConvertTo-Json $ret -Compress -Depth 2), (New-Object System.Text.UTF8Encoding($false)))
+                [System.IO.File]::WriteAllLines({ENV_FILE}, (ConvertTo-Json $ret -Compress -Depth 2 -WarningAction Ignore), (New-Object System.Text.UTF8Encoding($false)))
                 """.format(ENV_FILE=quotePwsh(PwshLanguage.__munge(envFile)))) if envFile else "",
             dedent("""\
                 cd $Env:BOB_CWD

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -208,7 +208,7 @@ class IfExpression():
         self.__expr = IfExpressionParser.getInstance().parseExpression(expr)
 
     def __eq__(self, other):
-        return self.__expr == other.__expr
+        return isinstance(other, IfExpression) and self.__expr == other.__expr
 
     def __lt__(self, other): return NotImplemented
     def __le__(self, other): return NotImplemented

--- a/test/black-box/checkout-update/classes/no-update.yaml
+++ b/test/black-box/checkout-update/classes/no-update.yaml
@@ -1,0 +1,4 @@
+inherit: [update]
+checkoutDeterministic: True
+checkoutScript: |
+    bumpCounter "no-update.txt"

--- a/test/black-box/checkout-update/classes/update.yaml
+++ b/test/black-box/checkout-update/classes/update.yaml
@@ -1,0 +1,14 @@
+checkoutUpdateIf: null
+checkoutDeterministic: True
+checkoutScript: |
+    bumpCounter()
+    {
+        local i
+        if [[ -r "$1" ]] ; then
+            read -r i < "$1"
+        else
+            i=0
+        fi
+        : $(( i++ ))
+        echo "$i" > "$1"
+    }

--- a/test/black-box/checkout-update/config.yaml
+++ b/test/black-box/checkout-update/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.21"

--- a/test/black-box/checkout-update/recipes/deterministic-root.yaml
+++ b/test/black-box/checkout-update/recipes/deterministic-root.yaml
@@ -1,0 +1,10 @@
+root: True
+inherit: [update, no-update]
+checkoutDeterministic: True
+checkoutUpdateIf: True
+checkoutScript: |
+    bumpCounter "root.txt"
+buildScript: |
+    cp "$1"/* .
+packageScript: |
+    cp "$1"/* .

--- a/test/black-box/checkout-update/recipes/indeterministic-root.yaml
+++ b/test/black-box/checkout-update/recipes/indeterministic-root.yaml
@@ -1,0 +1,9 @@
+root: True
+inherit: [update, no-update]
+checkoutUpdateIf: True
+checkoutScript: |
+    bumpCounter "root.txt"
+buildScript: |
+    cp "$1"/* .
+packageScript: |
+    cp "$1"/* .

--- a/test/black-box/checkout-update/run.sh
+++ b/test/black-box/checkout-update/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+. ../../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+cleanup
+
+# Test that on --build-only runs, the checkout scripts that are enabled via
+# checkoutUpdateIf.
+
+# checkout sources and remember state of deterministic checkout
+run_bob dev deterministic-root --build-only
+read -r CNT_ROOT_BASE < dev/src/deterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_BASE < dev/src/deterministic-root/1/workspace/no-update.txt
+
+# Running a deterministic checkout again does not update
+run_bob dev deterministic-root --build-only
+read -r CNT_ROOT_NEW < dev/src/deterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/deterministic-root/1/workspace/no-update.txt
+expect_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+
+# Changing the workspace and running deterministic checkout again does trigger
+# an update.
+echo foo > dev/src/deterministic-root/1/workspace/bar.txt
+run_bob dev deterministic-root --build-only
+read -r CNT_ROOT_NEW < dev/src/deterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/deterministic-root/1/workspace/no-update.txt
+expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+
+
+# checkout sources and remember state of indeterministic checkout
+run_bob dev indeterministic-root --build-only
+read -r CNT_ROOT_BASE < dev/src/indeterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_BASE < dev/src/indeterministic-root/1/workspace/no-update.txt
+
+# Running an indeterministic checkout again does update
+run_bob dev indeterministic-root --build-only
+read -r CNT_ROOT_NEW < dev/src/indeterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/indeterministic-root/1/workspace/no-update.txt
+expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+CNT_ROOT_BASE="$CNT_ROOT_NEW"
+
+# Changing the workspace and running deterministic checkout again does trigger
+# an update.
+echo foo > dev/src/indeterministic-root/1/workspace/bar.txt
+run_bob dev indeterministic-root --build-only
+read -r CNT_ROOT_NEW < dev/src/indeterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/indeterministic-root/1/workspace/no-update.txt
+expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"

--- a/test/black-box/fingerprints/recipes/conditional.yaml
+++ b/test/black-box/fingerprints/recipes/conditional.yaml
@@ -5,7 +5,8 @@ packageScript: |
     echo "${CANARY:-unset}" > result.txt
 
 # never fingerpint if $CANARY not set
-fingerprintIf: "$(ne,${CANARY:-},)"
+fingerprintIf: !expr |
+    "${CANARY:-}" != ""
 fingerprintScript: |
     touch $CANARY
     echo "${CANARY}"

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -198,3 +198,17 @@ die()
 	echo "$@"
 	exit 1
 }
+
+expect_equal()
+{
+	if [[ "$1" != "$2" ]] ; then
+		die "Failed: '$1' == '$2'"
+	fi
+}
+
+expect_not_equal()
+{
+	if [[ "$1" = "$2" ]] ; then
+		die "Failed: '$1' != '$2'"
+	fi
+}

--- a/test/unit/test_input_recipe.py
+++ b/test/unit/test_input_recipe.py
@@ -185,6 +185,11 @@ class TestDependencies(TestCase):
         self.cmpEntry(res[5], "f", checkoutDep=True)
 
 
+def applyRecipeDefaults(recipe):
+    r = recipe.copy()
+    r.setdefault("checkoutUpdateIf", False)
+    return r
+
 class TestRelocatable(TestCase):
 
     def parseAndPrepare(self, name, recipe, classes={}, allRelocatable=None):
@@ -195,13 +200,13 @@ class TestRelocatable(TestCase):
         recipeSet.scriptLanguage = ScriptLanguage.BASH
         recipeSet.getPolicy = lambda x: allRelocatable if x == 'allRelocatable' else None
 
-        cc = { n : Recipe(recipeSet, r, [], n+".yaml", cwd, n, n, {}, False)
+        cc = { n : Recipe(recipeSet, applyRecipeDefaults(r), [], n+".yaml",
+                          cwd, n, n, {}, False)
             for n, r in classes.items() }
         recipeSet.getClass = lambda x, cc=cc: cc[x]
 
-        r = recipe.copy()
-        r["root"] = True
-        ret = Recipe(recipeSet, recipe, [], name+".yaml", cwd, name, name, {})
+        ret = Recipe(recipeSet, applyRecipeDefaults(recipe), [], name+".yaml",
+                     cwd, name, name, {})
         ret.resolveClasses(Env())
         return ret.prepare(Env(), False, {})[0].refDeref([], {}, None, None)
 

--- a/test/unit/test_input_recipe.py
+++ b/test/unit/test_input_recipe.py
@@ -6,7 +6,7 @@ import os
 from bob.errors import ParseError
 from bob.input import Recipe
 from bob.languages import ScriptLanguage
-from bob.stringparser import Env
+from bob.stringparser import Env, IfExpression, DEFAULT_STRING_FUNS
 
 class TestDependencies(TestCase):
 
@@ -185,30 +185,37 @@ class TestDependencies(TestCase):
         self.cmpEntry(res[5], "f", checkoutDep=True)
 
 
-def applyRecipeDefaults(recipe):
-    r = recipe.copy()
-    r.setdefault("checkoutUpdateIf", False)
-    return r
+class RecipeCommon:
 
-class TestRelocatable(TestCase):
+    SCRIPT_LANGUAGE = ScriptLanguage.BASH
+
+    def applyRecipeDefaults(self, recipe):
+        r = recipe.copy()
+        r.setdefault("checkoutUpdateIf", False)
+        return r
 
     def parseAndPrepare(self, name, recipe, classes={}, allRelocatable=None):
 
         cwd = os.getcwd()
         recipeSet = MagicMock()
         recipeSet.loadBinary = MagicMock()
-        recipeSet.scriptLanguage = ScriptLanguage.BASH
+        recipeSet.scriptLanguage = self.SCRIPT_LANGUAGE
         recipeSet.getPolicy = lambda x: allRelocatable if x == 'allRelocatable' else None
 
-        cc = { n : Recipe(recipeSet, applyRecipeDefaults(r), [], n+".yaml",
+        cc = { n : Recipe(recipeSet, self.applyRecipeDefaults(r), [], n+".yaml",
                           cwd, n, n, {}, False)
             for n, r in classes.items() }
         recipeSet.getClass = lambda x, cc=cc: cc[x]
 
-        ret = Recipe(recipeSet, applyRecipeDefaults(recipe), [], name+".yaml",
+        env = Env()
+        env.funs = DEFAULT_STRING_FUNS
+        ret = Recipe(recipeSet, self.applyRecipeDefaults(recipe), [], name+".yaml",
                      cwd, name, name, {})
-        ret.resolveClasses(Env())
-        return ret.prepare(Env(), False, {})[0].refDeref([], {}, None, None)
+        ret.resolveClasses(env)
+        return ret.prepare(env, False, {})[0].refDeref([], {}, None, None)
+
+
+class TestRelocatable(RecipeCommon, TestCase):
 
     def testNormalRelocatable(self):
         """Normal recipes are relocatable by default"""
@@ -340,3 +347,167 @@ class TestRelocatable(TestCase):
         }
         p = self.parseAndPrepare("foo", recipe, allRelocatable=True)
         self.assertTrue(p.isRelocatable())
+
+
+class TestCheckoutUpdateIf(RecipeCommon, TestCase):
+
+    def testDefault(self):
+        """By default checkoutUpdateIf is 'False'"""
+
+        recipe = {
+            "checkoutScript" : "asdf",
+            "buildScript" : "asdf",
+            "packageScript" : "asdf",
+        }
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertFalse(c.getUpdateScript())
+        self.assertTrue(c.isUpdateDeterministic())
+
+    def testSimpleBool(self):
+        """checkoutUpdateIf can be a boolean value"""
+        recipe = {
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : True,
+            "buildScript" : "asdf",
+            "packageScript" : "asdf",
+        }
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertIn("asdf", c.getUpdateScript())
+
+    def testSimpleIfString(self):
+        """checkoutUpdateIf can be a boolean string value"""
+        recipe = {
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : "$(eq,a,b)",
+            "buildScript" : "asdf",
+            "packageScript" : "asdf",
+        }
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertNotIn("asdf", c.getUpdateScript())
+
+        recipe["checkoutUpdateIf"] = "$(eq,a,a)"
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertIn("asdf", c.getUpdateScript())
+
+    def testSimpleIfExpr(self):
+        """checkoutUpdateIf can be an IfExpression value"""
+        recipe = {
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : IfExpression('"a" == "b"'),
+            "buildScript" : "asdf",
+            "packageScript" : "asdf",
+        }
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertNotIn("asdf", c.getUpdateScript())
+
+        recipe["checkoutUpdateIf"] = IfExpression('"a" == "a"')
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertIn("asdf", c.getUpdateScript())
+
+    def testDeterministicDefault(self):
+        """checkoutDeterministic applies for updates too"""
+        recipe = {
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : True,
+            "buildScript" : "asdf",
+            "packageScript" : "asdf",
+        }
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertFalse(c.isUpdateDeterministic())
+
+        recipe["checkoutDeterministic"] = True
+        c = self.parseAndPrepare("foo", recipe).getCheckoutStep()
+        self.assertTrue(c.isUpdateDeterministic())
+
+    def testDeterministicInherit(self):
+        """checkoutDeterministic applies only for selected update parts"""
+
+        recipe = {
+            "inherit" : [ "bar" ],
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : True,
+            "checkoutDeterministic" : True,
+            "buildScript" : "asdf",
+        }
+        classes = {
+            "bar" : {
+                "checkoutScript" : "qwer",
+                "checkoutUpdateIf" : False,
+                "checkoutDeterministic" : False,
+                "buildScript" : "qwer",
+            },
+        }
+
+        c = self.parseAndPrepare("foo", recipe, classes).getCheckoutStep()
+        self.assertTrue(c.isUpdateDeterministic())
+
+    def testInherit(self):
+        """Only enabled checkoutScript takes part in update"""
+
+        recipe = {
+            "inherit" : [ "bar" ],
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : True,
+            "checkoutDeterministic" : True,
+            "buildScript" : "asdf",
+        }
+        classes = {
+            "bar" : {
+                "inherit" : [ "baz" ],
+                "checkoutScript" : "qwer",
+                "checkoutUpdateIf" : False,
+                "checkoutDeterministic" : False,
+                "buildScript" : "qwer",
+            },
+            "baz" : {
+                "relocatable" : True,
+                "checkoutScript" : "yxcv",
+                "checkoutUpdateIf" : True,
+                "buildScript" : "qwer",
+            },
+        }
+
+        c = self.parseAndPrepare("foo", recipe, classes).getCheckoutStep()
+        self.assertFalse(c.isUpdateDeterministic())
+        self.assertIn("asdf", c.getUpdateScript())
+        self.assertNotIn("qwer", c.getUpdateScript())
+        self.assertIn("yxcv", c.getUpdateScript())
+
+    def testInheritNullNotEnabled(self):
+        """A null checkoutUpdateIf does not yet enable the update script"""
+        recipe = {
+            "inherit" : [ "bar" ],
+            "checkoutScript" : "asdf",
+            "buildScript" : "asdf",
+        }
+        classes = {
+            "bar" : {
+                "checkoutScript" : "qwer",
+                "checkoutUpdateIf" : None,
+                "buildScript" : "qwer",
+            },
+        }
+
+        c = self.parseAndPrepare("foo", recipe, classes).getCheckoutStep()
+        self.assertNotIn("asdf", c.getUpdateScript())
+        self.assertNotIn("qwer", c.getUpdateScript())
+
+    def testInheritNullEnabled(self):
+        """A null checkoutUpdateIf is included if enabled elsewhere"""
+        recipe = {
+            "inherit" : [ "bar" ],
+            "checkoutScript" : "asdf",
+            "checkoutUpdateIf" : True,
+            "buildScript" : "asdf",
+        }
+        classes = {
+            "bar" : {
+                "checkoutScript" : "qwer",
+                "checkoutUpdateIf" : None,
+                "buildScript" : "qwer",
+            },
+        }
+
+        c = self.parseAndPrepare("foo", recipe, classes).getCheckoutStep()
+        self.assertIn("asdf", c.getUpdateScript())
+        self.assertIn("qwer", c.getUpdateScript())


### PR DESCRIPTION
By default no checkout scripts are run when building with `--build-only`.
Some use cases practically require the `checkoutScript` to be always run,
through. A typical example are code generators that generate sources
from some high level description. These generators must be run every
time when the user has changed the input. A recipe or class can
explicitly opt in to run their `checkoutScript` also in build-only mode to
cover such a use case. This is done by either setting `checkoutUpdateIf`
to `True` or by a boolean expression that is evaluated to `True`. Otherwise
the `checkoutScript` is ignored even if some other class enables its
script. The `checkoutUpdateIf` property thus only applies to the
corresponding `checkoutScript` in the same recipe/class.