### PR TITLE
generators: fix crash on packages without checkout

### DIFF
--- a/pym/bob/generators/common.py
+++ b/pym/bob/generators/common.py
@@ -184,7 +184,7 @@ class CommonIDEGenerator:
                 self.checkout = False
                 self.dependencies = set()
 
-        checkouts = { False : CheckoutInfo(None, None) }
+        checkouts = { False : CheckoutInfo(BaseScanner(), None) }
         packages = {}
 
         def collect(package, rootPackage=True):


### PR DESCRIPTION
If a package has a host executable file but has no checkout step, the common scanner would fail:

  ...
  File "C:\Projects\tools\bob\pym\bob\generators\common.py", line 246, in collect
  collect(d.getPackage(), False)
  File "C:\Projects\tools\bob\pym\bob\generators\common.py", line 224, in collect
  info.scan._addRunTarget(target)
  AttributeError: 'NoneType' object has no attribute '_addRunTarget'

Use a correct sentinel to mock the expected interface.

Fixes #498.