### PR TITLE
tty: make the MassiveParallelTUI threshold settable

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -2466,6 +2466,12 @@ color
     ``auto``
         Use colors only when TTY console detected (default)
 
+parallelTUIThreshold
+    Set the threshold for switching between TUIs. Default: 16
+
+    If the number of jobs exceeds this threshold the TUI switches from one
+    status line per job to a TUI using only two status lines.
+
 queryMode
     Set the behaviour of package queries when no package is matched. Can be
     overridden on the command line by the global ``--query`` option of

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -11,7 +11,7 @@ from .scm import CvsScm, GitScm, ImportScm, SvnScm, UrlScm, ScmOverride, \
     auditFromDir, getScm, SYNTHETIC_SCM_PROPS
 from .state import BobState
 from .stringparser import checkGlobList, Env, DEFAULT_STRING_FUNS, IfExpression
-from .tty import InfoOnce, Warn, WarnOnce, setColorMode
+from .tty import InfoOnce, Warn, WarnOnce, setColorMode, setParallelTUIThreshold
 from .utils import asHexStr, joinScripts, compareVersion, binStat, \
     updateDicRecursive, hashString, getPlatformTag, getPlatformString, \
     replacePath
@@ -3162,6 +3162,7 @@ class RecipeSet:
             "ui" : BuiltinSetting(
                 schema.Schema({
                     schema.Optional('color') : schema.Or('never', 'always', 'auto'),
+                    schema.Optional('parallelTUIThreshold') : int,
                     schema.Optional('queryMode') : schema.Or('nullset', 'nullglob', 'nullfail'),
                 }),
                 lambda x: updateDicRecursive(self.__uiConfig, x)
@@ -3539,6 +3540,7 @@ class RecipeSet:
         # color mode provided in cmd line takes precedence
         # (if no color mode provided by user, default one will be used)
         setColorMode(self._colorModeConfig or self.__uiConfig.get('color', 'auto'))
+        setParallelTUIThreshold(self.__uiConfig.get('parallelTUIThreshold', 16))
 
         # finally parse recipes
         classesDir = os.path.join(rootDir, 'classes')

--- a/pym/bob/tty.py
+++ b/pym/bob/tty.py
@@ -567,7 +567,7 @@ def setTui(maxJobs):
     if maxJobs <= 1:
         __tui = SingleTUI(__tui.getVerbosity())
     elif __onTTY:
-        if maxJobs <= 16:
+        if maxJobs <= __parallelTUIThreshold:
             __tui = ParallelTtyUI(__tui.getVerbosity(), maxJobs)
         else:
             __tui = MassiveParallelTtyUI(__tui.getVerbosity(), maxJobs)
@@ -594,6 +594,7 @@ def ttyReinit():
 __onTTY = (sys.stdout.isatty() and sys.stderr.isatty())
 __useColor = False
 __tui = SingleTUI(NORMAL)
+__parallelTUIThreshold = 16
 
 if __onTTY and sys.platform == "win32":
     # Try to set ENABLE_VIRTUAL_TERMINAL_PROCESSING flag. Enables vt100 color
@@ -615,6 +616,10 @@ def setColorMode(mode):
         __useColor = True
     elif mode == 'auto':
         __useColor = __onTTY
+
+def setParallelTUIThreshold(num):
+    global __parallelTUIThreshold
+    __parallelTUIThreshold = num
 
 # auto is the default
 setColorMode('auto')


### PR DESCRIPTION
Make the threshold customizable as some people were confused about the new MassiveParallelTUI. They wished to get the old TUI back without being limited to 16 jobs.