### PR TITLE
generators: fix ParseError reporting

### DIFF
--- a/pym/bob/generators/EclipseCdtGenerator.py
+++ b/pym/bob/generators/EclipseCdtGenerator.py
@@ -14,6 +14,7 @@ import uuid
 from os.path import expanduser
 from os.path import join
 from bob.utils import summonMagic, removePath
+from bob.errors import ParseError
 from collections import OrderedDict
 from shlex import quote
 
@@ -233,7 +234,7 @@ def eclipseCdtGenerator(package, argv, extra, bobRoot):
             if os.path.exists(i):
                 includeDirs.append(i)
     except re.error as e:
-        raise ParseError("Invalid regular expression '{}': {}".format(e.pattern), e)
+        raise ParseError("Invalid regular expression '{}': {}".format(e.pattern, e))
 
     with open(os.path.join(destination, ".cproject"), 'w') as cProjectFile:
         cProjectFile.write(cProjectHeader)

--- a/pym/bob/generators/QtCreatorGenerator.py
+++ b/pym/bob/generators/QtCreatorGenerator.py
@@ -15,7 +15,7 @@ import shutil
 from os.path import expanduser
 from os.path import join
 from bob.utils import removePath, isWindows
-from bob.errors import BuildError
+from bob.errors import BuildError, ParseError
 from bob.utils import summonMagic, hashFile
 from collections import OrderedDict, namedtuple
 from bob.tty import colorize, WARNING
@@ -227,7 +227,7 @@ def qtProjectGenerator(package, argv, extra, bobRoot):
         else:
             _kit = re.compile(r""+args.kit)
     except re.error as e:
-        raise ParseError("Invalid regular expression '{}': {}".format(e.pattern), e)
+        raise ParseError("Invalid regular expression '{}': {}".format(e.pattern, e))
 
     getCheckOutDirs(package, excludes, dirs)
     if not projectName:


### PR DESCRIPTION
If a invalid regular expression is provided a parse error should be shown. Unfortunately the error reporting was broken and raised another exception:

    raise ParseError("Invalid regular expression '{}': {}".format(e.pattern), e)
 NameError: name 'ParseError' is not defined

    raise ParseError("Invalid regular expression '{}': {}".format(e.pattern), e)
 IndexError: Replacement index 1 out of range for positional args tuple