### PR TITLE
project-generators: enable use of query language

### DIFF
--- a/doc/manual/extending.rst
+++ b/doc/manual/extending.rst
@@ -239,7 +239,7 @@ default implementation in Bob looks like this::
 Generators
 ----------
 
-The main purpose of a generator is to generate project files for one or more IDEs. 
+The main purpose of a generator is to generate project files for one or more IDEs.
 There are several built-in generators, e.g. for QtCreator project files.
 
 A generator is called with at least 3 arguments:
@@ -271,6 +271,29 @@ A simple generator may look like::
             'nullGenerator' : nullGenerator,
         }
     }
+
+Traditionally a generator handles only one package. When running the generator
+this package needs to be provided using the complete path. Starting with Bob
+0.23 a generator can specify that he can handle multiple packages as a result
+of a :ref:`package query <manpage-bobpaths>`. This is done by setting the
+optional `query` property to `True`. In this case the first argument of the
+generator are the package objects returned by
+:func:`bob.pathspec.PackageSet.queryPackagePath`.::
+
+   def nullQueryGenerator(packages, argv, extra, bob):
+       for p in packages:
+           print(p.getName())
+       return 0
+
+   manifest = {
+        'apiVersion' : "0.23",
+        'projectGenerators' : {
+            'nullQueryGenerator' : {
+               'func' : nullQueryGenerator,
+               'query' : True,
+        }
+    }
+
 
 .. _extending-settings:
 

--- a/pym/bob/cmds/build/project.py
+++ b/pym/bob/cmds/build/project.py
@@ -107,7 +107,11 @@ def doProject(argv, bobRoot):
             parser.error("--jobs argument must be greater than zero!")
         extra.extend(['-j', str(args.jobs)])
 
-    package = packages.walkPackagePath(args.package)
+    if generator.get('query'):
+        package = packages.queryPackagePath(args.package)
+    else:
+        package = packages.walkPackagePath(args.package)
+        print(">>", colorize("/".join(package.getStack()), "32;1"))
 
     # execute a bob dev with the extra arguments to build all executables.
     # This makes it possible for the plugin to collect them and generate some runTargets.
@@ -118,7 +122,6 @@ def doProject(argv, bobRoot):
         devArgs.append(args.package)
         doDevelop(devArgs, bobRoot)
 
-    print(">>", colorize("/".join(package.getStack()), "32;1"))
     print(colorize("   PROJECT   {} ({})".format(args.package, args.projectGenerator), "32"))
-    generator(package, args.args, extra, bobRoot)
+    generator.get('func')(package, args.args, extra, bobRoot)
 

--- a/pym/bob/generators/__init__.py
+++ b/pym/bob/generators/__init__.py
@@ -7,11 +7,17 @@ import sys
 __all__ = ['generators']
 
 generators = {
-    'eclipseCdt' : eclipseCdtGenerator,
-    'qt-creator' : qtProjectGenerator,
-    'vscode': vsCodeProjectGenerator
+    'eclipseCdt' :{
+        'func' : eclipseCdtGenerator,
+        'query' : False},
+    'qt-creator' : {
+        'func' : qtProjectGenerator,
+        'query' : False},
+    'vscode': {
+        'func' : vsCodeProjectGenerator,
+        'query' : False}
 }
 
 if isWindows():
     from .VisualStudio import vs2019ProjectGenerator
-    generators['vs2019'] = vs2019ProjectGenerator
+    generators['vs2019'] = {'func' : vs2019ProjectGenerator, 'query' : False}

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3287,6 +3287,10 @@ class RecipeSet:
                     name : lambda package, args, extra, bobRoot: generator(package, args, extra)
                     for name, generator in projectGenerators.items()
                 }
+            projectGenerators = {
+                name : generator if isinstance(generator, dict) else {'func' :  generator, 'query' : False }
+                for name, generator in projectGenerators.items()
+            }
             self.__projectGenerators.update(projectGenerators)
 
         properties = manifest.get('properties', {})

--- a/test/black-box/generator/config.yaml
+++ b/test/black-box/generator/config.yaml
@@ -2,5 +2,6 @@ bobMinimumVersion: "0.4"
 
 plugins:
     - "generator"
+    - "g2"
     - "vs"
 

--- a/test/black-box/generator/output-plugin-g2.txt
+++ b/test/black-box/generator/output-plugin-g2.txt
@@ -1,0 +1,3 @@
+G2:  root
+G2:  root-2
+G2:  root-3

--- a/test/black-box/generator/plugins/g2.py
+++ b/test/black-box/generator/plugins/g2.py
@@ -1,0 +1,13 @@
+def g2(packages, argv, extra, bobRoot):
+    for p in packages:
+        print("G2: ", p.getName())
+
+manifest = {
+    'apiVersion' : "0.22.1.dev24",
+    'projectGenerators' : {
+        "g2" : {
+            "func" : g2,
+            "query" : True
+        }
+    }
+}

--- a/test/black-box/generator/recipes/root.yaml
+++ b/test/black-box/generator/recipes/root.yaml
@@ -6,6 +6,18 @@ depends:
 checkoutScript: |
     cp $<<src/main.c>> main.c
 
+multiPackage:
+   "":
+      environment:
+         FOO: "1"
+   "2":
+      environment:
+         FOO: "2"
+   "3":
+      environment:
+         FOO: "3"
+
+buildVars: [FOO]
 buildScript:
     cp $1/main.c .
 

--- a/test/black-box/generator/run.sh
+++ b/test/black-box/generator/run.sh
@@ -11,6 +11,9 @@ fi
 run_bob project -n g1 root > log-cmd.txt
 diff -uZ <(grep '^PLUGIN' log-cmd.txt) output-plugin.txt
 
+run_bob project -n g2 root* > log-cmd.txt
+diff -uZ <(grep '^G2' log-cmd.txt) output-plugin-g2.txt
+
 # run and generate
 run_bob project qt-creator root --kit 'dummy' > log-cmd.txt
 RES=$(sed -ne '/^Build result is in/s/.* //p' log-cmd.txt)


### PR DESCRIPTION
While many of the generators do not need it there are use cases where a generator needs to handle a pathspec rather than a package-path.