### PR TITLE
Run changed checkoutScript in build-only mode

### DIFF
--- a/doc/manual/policies.rst
+++ b/doc/manual/policies.rst
@@ -563,3 +563,30 @@ Old behavior
 New behavior
    Bob checks if the ``commit`` and / or ``tag`` is on the configured ``branch`` and
    performs a checkout of the ``commit`` on a local ``branch``.
+
+fixImportScmVariant
+~~~~~~~~~~~~~~~~~~~
+
+Introduced in: 0.23
+
+Bob uses the concept of a :term:`Variant-Id` to track *how* a package is built.
+This includes the sub-directory in which a particular SCM is checked out. So if
+the ``dir`` attribute of an SCM changes, the respective Variant-Id of the
+package changes too. Bob versions before 0.23 contained a bug where the ``dir``
+attribute of an ``import`` SCM was not included in the Variant-Id calculation.
+This can cause build failures or wrongly used binary artifacts if just the
+``dir`` attribute of an ``import`` SCM is changed.
+
+Fixing the bug will affect the :term:`Variant-Id` of all packages that use an
+``import`` SCM. This implies that binary artifacts of such packages will need
+to be built again. It also transitively affects packages that depend on
+packages that utilize an ``import`` SCM.
+
+Old behavior
+   Changes to the ``dir`` attribute of an ``import`` SCM do not cause rebuilds
+   of the affected package. Wrong sharing of binary artifacts for such packages
+   may occur.
+
+New behavior
+   Changes to the ``dir`` attribute of an ``import`` SCM behave the same as for
+   any other SCM.

--- a/pym/bob/cmds/build/clean.py
+++ b/pym/bob/cmds/build/clean.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from ...builder import LocalBuilder
+from ...builder import LocalBuilder, checkoutsFromState
 from ...input import RecipeSet
 from ...scm import getScm, ScmTaint, ScmStatus
 from ...share import getShare
@@ -55,7 +55,6 @@ def collectPaths(rootPackage):
     return paths
 
 def checkSCM(workspace, scmDir, scmSpec, verbose):
-    if scmDir is None: return True
     if scmSpec is not None:
         status = getScm(scmSpec).status(workspace)
     else:
@@ -78,7 +77,7 @@ def checkSCM(workspace, scmDir, scmSpec, verbose):
 def checkRegularSource(workspace, verbose):
     ret = True
     state = BobState().getDirectoryState(workspace, True)
-    for (scmDir, (scmDigest, scmSpec)) in state.items():
+    for (scmDir, (scmDigest, scmSpec)) in checkoutsFromState(state):
         if not checkSCM(workspace, scmDir, scmSpec, verbose):
             ret = False
 

--- a/pym/bob/cmds/build/status.py
+++ b/pym/bob/cmds/build/status.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from ...builder import LocalBuilder
+from ...builder import LocalBuilder, checkoutsFromState
 from ...input import RecipeSet
 from ...scm import getScm, ScmTaint, ScmStatus
 from ...state import BobState
@@ -112,8 +112,7 @@ class Printer:
         # First scan old checkout state. This is what the user is most
         # interested in. The recipe might have changed compared to the
         # persisted state!
-        for (scmDir, (scmDigest, scmSpec)) in oldCheckoutState.items():
-            if scmDir is None: continue # checkoutScript state -> ignored
+        for (scmDir, (scmDigest, scmSpec)) in checkoutsFromState(oldCheckoutState):
             if not os.path.exists(os.path.join(workspace, scmDir)): continue
 
             if scmDigest == checkoutState.get(scmDir, (None, None))[0]:
@@ -208,10 +207,10 @@ class Printer:
                 BobState().delDirectoryState(workspace)
                 continue
 
-            # Upgrade from old format without scmSpec. Drop None dir.
+            # Upgrade from old format without scmSpec.
             dirState = sorted(
                 (dir, state) if isinstance(state, tuple) else (dir, (state, None))
-                for dir,state in dirState.items() if dir is not None)
+                for dir,state in checkoutsFromState(dirState))
             for (scmDir, (scmDigest, scmSpec)) in dirState:
                 scmDir = os.path.join(workspace, scmDir)
                 if scmSpec is not None:

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2985,6 +2985,7 @@ class RecipeSet:
                 schema.Optional('scmIgnoreUser') : bool,
                 schema.Optional('pruneImportScm') : bool,
                 schema.Optional('gitCommitOnBranch') : bool,
+                schema.Optional('fixImportScmVariant') : bool,
             },
             error="Invalid policy specified! Maybe your Bob is too old?"
         ),
@@ -3111,6 +3112,11 @@ class RecipeSet:
                 "0.21.0.dev5",
                 InfoOnce("gitCommitOnBranch policy not set. Will not check if commit / tag is on configured branch.",
                     help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#gitcommitonbranch for more information.")
+            ),
+            'fixImportScmVariant' : (
+                "0.22.1.dev34",
+                InfoOnce("fixImportScmVariant policy not set. Recipe variant calculation w/ import SCM is boguous.",
+                    help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#fiximportscmvariant for more information.")
             ),
         }
         self.__buildHooks = {}

--- a/pym/bob/intermediate.py
+++ b/pym/bob/intermediate.py
@@ -549,6 +549,7 @@ class RecipeSetIR:
             'tidyUrlScm' : recipeSet.getPolicy('tidyUrlScm'),
             'sandboxFingerprints' : recipeSet.getPolicy('sandboxFingerprints'),
             'gitCommitOnBranch' : recipeSet.getPolicy('gitCommitOnBranch'),
+            'fixImportScmVariant' : recipeSet.getPolicy('fixImportScmVariant'),
         }
         self.__data['archiveSpec'] = recipeSet.archiveSpec()
         self.__data['envWhiteList'] = sorted(recipeSet.envWhiteList())

--- a/pym/bob/scm/__init__.py
+++ b/pym/bob/scm/__init__.py
@@ -51,6 +51,7 @@ def getScm(spec, overrides=[], recipeSet=None):
     elif scm == "import":
         return ImportScm(spec, overrides,
             recipeSet and recipeSet.getPolicy('pruneImportScm'),
+            recipeSet and recipeSet.getPolicy('fixImportScmVariant'),
             recipeSet and recipeSet.getProjectRoot())
     elif scm == "svn":
         return SvnScm(spec, overrides)

--- a/pym/bob/scm/imp.py
+++ b/pym/bob/scm/imp.py
@@ -127,13 +127,14 @@ class ImportScm(Scm):
 
     SCHEMA = schema.Schema({**__SCHEMA, **DEFAULTS})
 
-    def __init__(self, spec, overrides=[], pruneDefault=None, projectRoot=""):
+    def __init__(self, spec, overrides=[], pruneDefault=None, fixDigestBug=False, projectRoot=""):
         super().__init__(spec, overrides)
         self.__url = spec["url"]
         self.__dir = spec.get("dir", ".")
         self.__prune = spec.get("prune", pruneDefault or False)
         self.__data = spec.get("__data")
         self.__projectRoot = spec.get("__projectRoot", projectRoot)
+        self.__fixDigestBug = fixDigestBug
 
     def getProperties(self, isJenkins):
         ret = super().getProperties(isJenkins)
@@ -162,7 +163,10 @@ class ImportScm(Scm):
             unpackTree(self.__data, dest)
 
     def asDigestScript(self):
-        return self.__url
+        if self.__fixDigestBug:
+            return self.__url + " " + self.__dir
+        else:
+            return self.__url
 
     def getDirectory(self):
         return self.__dir

--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -289,8 +289,9 @@ class _BobState():
     #  5 -> 6: build state stores predicted live-build-ids too
     #  6 -> 7: amended directory state for source steps, store attic directories
     #  7 -> 8: normalize attic directories
+    #  8 -> 9: checkout directory state tracks import scm / update script state
     MIN_VERSION = 2
-    CUR_VERSION = 8
+    CUR_VERSION = 9
 
     VERSION_SINCE_ATTIC_TRACKED = 7
 

--- a/test/black-box/checkout-update/recipes/deterministic-root.yaml
+++ b/test/black-box/checkout-update/recipes/deterministic-root.yaml
@@ -2,6 +2,7 @@ root: True
 inherit: [update, no-update]
 checkoutDeterministic: True
 checkoutUpdateIf: True
+checkoutVars: [DUMMY]
 checkoutScript: |
     bumpCounter "root.txt"
 buildScript: |

--- a/test/black-box/checkout-update/run.sh
+++ b/test/black-box/checkout-update/run.sh
@@ -25,7 +25,25 @@ read -r CNT_ROOT_NEW < dev/src/deterministic-root/1/workspace/root.txt
 read -r CNT_NO_UPDATE_NEW < dev/src/deterministic-root/1/workspace/no-update.txt
 expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
 expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+CNT_ROOT_BASE="$CNT_ROOT_NEW"
 
+# Changing the checkout script will run the deterministic checkout again
+run_bob dev deterministic-root --build-only -DDUMMY=foo
+read -r CNT_ROOT_NEW < dev/src/deterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/deterministic-root/1/workspace/no-update.txt
+expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+CNT_ROOT_BASE="$CNT_ROOT_NEW"
+
+# Running with the same checkout script won't run the deterministic checkout
+# again
+run_bob dev deterministic-root --build-only -DDUMMY=foo
+read -r CNT_ROOT_NEW < dev/src/deterministic-root/1/workspace/root.txt
+read -r CNT_NO_UPDATE_NEW < dev/src/deterministic-root/1/workspace/no-update.txt
+expect_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
+expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+
+### indeterministic tests #####################################################
 
 # checkout sources and remember state of indeterministic checkout
 run_bob dev indeterministic-root --build-only
@@ -48,3 +66,4 @@ read -r CNT_ROOT_NEW < dev/src/indeterministic-root/1/workspace/root.txt
 read -r CNT_NO_UPDATE_NEW < dev/src/indeterministic-root/1/workspace/no-update.txt
 expect_not_equal "$CNT_ROOT_BASE" "$CNT_ROOT_NEW"
 expect_equal "$CNT_NO_UPDATE_BASE" "$CNT_NO_UPDATE_NEW"
+CNT_ROOT_BASE="$CNT_ROOT_NEW"

--- a/test/black-box/import-scm/config.yaml
+++ b/test/black-box/import-scm/config.yaml
@@ -1,1 +1,2 @@
-bobMinimumVersion: "0.17"
+# Include fixImportScmVariant policy
+bobMinimumVersion: "0.22.1.dev34"

--- a/test/black-box/import-scm/root.yaml
+++ b/test/black-box/import-scm/root.yaml
@@ -3,5 +3,6 @@ checkoutSCM:
     scm: import
     url: src
     prune: False
+    dir: "${IMPORT_DIR:-.}"
 buildScript: cp -a "$1/"* .
 packageScript: cp -a "$1/"* .

--- a/test/black-box/import-scm/root.yaml
+++ b/test/black-box/import-scm/root.yaml
@@ -2,5 +2,6 @@ root: True
 checkoutSCM:
     scm: import
     url: src
+    prune: False
 buildScript: cp -a "$1/"* .
 packageScript: cp -a "$1/"* .


### PR DESCRIPTION
If a recipe utilizes `checkoutUpdateIf`, relax the checks so that also modified `checkoutScript`s are run in build-only mode.

@rhubert  Could you please give it a try?

:warning: This change bumps the project state version. Once used in a build tree, there is no going back to an older Bob version! So maybe better test it in a new build tree.