### PR TITLE
build: add no-force-branch switch

### DIFF
--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -127,7 +127,7 @@ __bob_cook()
    elif [[ "$prev" = "--always-checkout" ]] ; then
       COMPREPLY=( )
    else
-      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --clean-checkout --attic --no-attic"
+      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --clean-checkout --attic --no-attic --no-commit-on-branch --commit-on-branch"
    fi
 }
 

--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -103,6 +103,10 @@ Options
     forced=<layer regex>
       like 'yes' above, but fail if any download fails
 
+
+``--force-branch``
+    Inverse option of ``--no-force-branch``.
+
 ``--incremental``
     Reuse build directory for incremental builds.
 
@@ -237,6 +241,12 @@ Options
 ``--no-attic``
     Do not move checkout workspace to attic if inline SCM switching is not possible.
     Instead a build error is issued.
+
+``--no-force-branch``
+    If a commit/tag doesn't exist on the configured branch the checkout fails if
+    gitCommitOnBranch policy is enabled. Use this switch to checkout the commit/tag
+    without a branch instead which will leave the workspace in detached HEAD state.
+    This has only a effect for git scms.
 
 ``-n, --no-deps``
     Don't build dependencies.

--- a/doc/manpages/bob-build.rst
+++ b/doc/manpages/bob-build.rst
@@ -24,6 +24,7 @@ Synopsis
               [--shared | --no-shared] [--install | --no-install]
               [--sandbox | --no-sandbox] [--clean-checkout]
               [--attic | --no-attic]
+              [--force-branch | --no-force-branch]
               PACKAGE [PACKAGE ...]
 
 

--- a/doc/manpages/bob-dev.rst
+++ b/doc/manpages/bob-dev.rst
@@ -23,6 +23,7 @@ Synopsis
             [--no-link-deps] [--download MODE] [--download-layer MODE]
             [--shared | --no-shared] [--install | --no-install]
             [--sandbox | --no-sandbox] [--clean-checkout]
+            [--force-branch | --no-force-branch]
             [--attic | --no-attic]
             PACKAGE [PACKAGE ...]
 

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -2278,34 +2278,35 @@ Set default build arguments here. See :ref:`manpage-dev` or
 
 The following table lists possible arguments and their type:
 
-=============== ====================== ===============================================
-Key             Command line switch    Type
-=============== ====================== ===============================================
-always_checkout ``--always-checkout``  List of strings (regular expression patterns)
-attic           ``--[no]-attic``       Boolean
-audit           ``--[no]-audit``       Boolean
-build_mode      ``-b`` | ``-B`` |      String (``normal``, ``build-only`` or
-                ``--normal``           ``checkout-only``)
-clean           ``--clean`` |          Boolean
+=============== ======================== ===============================================
+Key             Command line switch      Type
+=============== ======================== ===============================================
+always_checkout ``--always-checkout``    List of strings (regular expression patterns)
+attic           ``--[no]-attic``         Boolean
+audit           ``--[no]-audit``         Boolean
+build_mode      ``-b`` | ``-B`` |        String (``normal``, ``build-only`` or
+                ``--normal``             ``checkout-only``)
+clean           ``--clean`` |            Boolean
                 ``--incremental``
-clean_checkout  ``--clean-checkout``   Boolean
-destination     ``--destination``      String (Path)
-download        ``--download``         String (``yes``, ``no``, ``deps``, ``forced``,
-                                       ``forced-deps``, ``forced-fallback`` or
-                                       ``packages=<packages>``)
-download_layer  ``--download-layer``   List of strings (``yes=<layer>``,
-                                       ``no=<layer>``, ``forced=<layer>```)
-force           ``-f``                 Boolean
-install         ``--[no-]install``     Boolean
-jobs            ``-j``                 Integer
-link_deps       ``--[no-]link-deps``   Boolean
-no_deps         ``-n``                 Boolean
-no_logfiles     ``--no-logfiles``      Boolean
-sandbox         ``--[no-]sandbox``     Boolean
-shared          ``--[no-]shared``      Boolean
-upload          ``--upload``           Boolean
-verbosity       ``-q | -v``            Integer (-2[quiet] .. 3[verbose], default 0)
-=============== ====================== ===============================================
+clean_checkout  ``--clean-checkout``     Boolean
+destination     ``--destination``        String (Path)
+download        ``--download``           String (``yes``, ``no``, ``deps``, ``forced``,
+                                         ``forced-deps``, ``forced-fallback`` or
+                                         ``packages=<packages>``)
+download_layer  ``--download-layer``     List of strings (``yes=<layer>``,
+                                         ``no=<layer>``, ``forced=<layer>```)
+force           ``-f``                   Boolean
+force_branch    ``--[no-]-force-branch`` Boolean
+install         ``--[no-]install``       Boolean
+jobs            ``-j``                   Integer
+link_deps       ``--[no-]link-deps``     Boolean
+no_deps         ``-n``                   Boolean
+no_logfiles     ``--no-logfiles``        Boolean
+sandbox         ``--[no-]sandbox``       Boolean
+shared          ``--[no-]shared``        Boolean
+upload          ``--upload``             Boolean
+verbosity       ``-q | -v``              Integer (-2[quiet] .. 3[verbose], default 0)
+=============== ======================== ===============================================
 
 graph
 ^^^^^

--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -359,6 +359,7 @@ cd {ROOT}
         self.__installSharedPackages = False
         self.__executor = None
         self.__attic = True
+        self.__forceBranch = None
 
     def setExecutor(self, executor):
         self.__executor = executor
@@ -433,6 +434,9 @@ cd {ROOT}
 
     def setJobs(self, jobs):
         self.__jobs = max(jobs, 1)
+
+    def setForceBranch(self, value):
+        self.__forceBranch = value
 
     def setMakeFds(self, makeFds):
         self.__makeFds = makeFds
@@ -734,6 +738,7 @@ cd {ROOT}
             executor=self.__executor)
         if step.jobServer() and self.__jobServer:
             invoker.setMakeParameters(self.__jobServer.getMakeFd(), self.__jobs)
+        invoker.setExtra("forceBranch", self.__forceBranch)
         ret = await invoker.executeStep(mode, cleanWorkspace)
         if not self.__bufferedStdIO: ttyReinit() # work around MSYS2 messing up the console
         if ret == -int(signal.SIGINT):

--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -211,6 +211,13 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         help="Move scm to attic if inline switch is not possible (default).")
     group.add_argument('--no-attic', action='store_false', default=None, dest='attic',
         help="Do not move to attic, instead fail the build.")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--force-branch', action='store_true', default=None,
+        dest="force_branch", help="Raise build error if a commit is not on the configured branch. (git-only")
+    group.add_argument('--no-force-branch', action='store_false', default=None,
+        dest='force_branch', help="Do not raise a build error if a commit is not on the configured branch.")
+
     args = parser.parse_args(argv)
 
     defines = processDefines(args.defines)
@@ -251,6 +258,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
                 'shared' : True,
                 'install' : True,
                 'attic' : True,
+                'force_branch' : None,
             }
 
         for a in vars(args):
@@ -319,6 +327,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         builder.setShareHandler(getShare(recipes.getShareConfig()))
         builder.setShareMode(args.shared, args.install)
         builder.setAtticEnable(args.attic)
+        builder.setForceBranch(args.force_branch)
         if args.resume: builder.loadBuildState()
 
         backlog = []

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2941,6 +2941,7 @@ class RecipeSet:
             schema.Optional('build_mode') : schema.Or("build-only","normal", "checkout-only"),
             schema.Optional('clean') : bool,
             schema.Optional('clean_checkout') : bool,
+            schema.Optional('force_branch') : bool,
             schema.Optional('destination') : str,
             schema.Optional('download') : schema.Or("yes", "no", "deps",
                 "forced", "forced-deps", "forced-fallback",

--- a/pym/bob/invoker.py
+++ b/pym/bob/invoker.py
@@ -99,6 +99,7 @@ class Invoker:
         self.__stdioBuffer = io.BytesIO() if redirect else None
         self.__warnedDuplicates = { '' }
         self.__executor = executor
+        self.__extra = {}
 
         # Redirection is a bit complicated. We have to consider two levels: the
         # optional log file and the console.
@@ -574,3 +575,9 @@ class Invoker:
     async def runInExecutor(self, func, *args):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(self.__executor, func, *args)
+
+    def setExtra(self, name, value):
+        self.__extra[name] = value
+
+    def getExtra(self, name):
+        return self.__extra[name] if name in self.__extra else None

--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -262,7 +262,11 @@ class GitScm(Scm):
         if await invoker.callCommand(["git", "merge-base", "--is-ancestor",
                                      commit, "remotes/origin/"+self.__branch],
                                      cwd=self.__dir):
-            invoker.fail("Branch '{}' does not contain '{}'".format(self.__branch, commit))
+            if invoker.getExtra("forceBranch") is None or invoker.getExtra("forceBranch"):
+                invoker.fail("Branch '{}' does not contain '{}'".format(self.__branch, commit))
+            else:
+                # fall back to checkoutTag to checkout the configured tag/branch to detached HEAD
+                return await self.__checkoutTag(invoker, fetchCmd, switch)
 
         if headValid:
             branchExists = (await invoker.callCommand(["git", "show-ref", "-q",

--- a/test/black-box/git-scm-switch/run.sh
+++ b/test/black-box/git-scm-switch/run.sh
@@ -142,3 +142,7 @@ run_bob dev -c submodules -DSCM_DIR="$git_dir1" -DSCM_REV="$d1_c1" -DSCM_BRANCH=
 expect_output "foobar" git -C dev/src/root2/1/workspace rev-parse --abbrev-ref HEAD
 expect_output "$d1_c1" git -C dev/src/root2/1/workspace rev-parse HEAD
 expect_exist dev/src/root2/1/workspace/submod/sub.txt
+
+# test `no-force-branch` switch
+cleanup
+run_bob dev -DSCM_REV="$d1_c2" -DSCM_DIR="$git_dir1" -DSCM_BRANCH=master root2 -vv --no-force-branch


### PR DESCRIPTION
A common workflow is to:
- write some code in a components repo
- push it to a feature branch
- write the new commitID of the component into the recipe
- use bob dev ...

With activated gitCommitOnBranch policy this is no longer possible if there is also a branch configured in the recipe as the build bails out with something like:
```
  Branch XXX does not contain abcdef.
```

With `--no-force-branch`  the branch is ignored and the commit is checked out (results in detached HEAD) making it possible to resume work without a scmOverride.