### PR TITLE
git: inline switch when reference changes

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -508,7 +508,9 @@ class GitScm(Scm):
 
         # Filter irrelevant properties
         diff -= {"sslVerify", 'singleBranch', 'shallow',
-                'shallowSubmodules', "useBranchAndCommit"}
+                'shallowSubmodules', "useBranchAndCommit",
+                "references", "dissociate"}
+
         diff = set(prop for prop in diff if not prop.startswith("remote-"))
 
         # Enabling "submodules" and/or "recurseSubmodules" is ok. The


### PR DESCRIPTION
There is no need to move the workspace to attic if the reference or dissociate are changed.