### PR TITLE
scm/url: fix crash if no extractor is installed

### DIFF
--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -368,7 +368,7 @@ class UrlScm(Scm):
                 os.utime(canary)
                 break
             else:
-                executor.fail("No suitable extractor found!")
+                invoker.fail("No suitable extractor found!")
 
     def asDigestScript(self):
         """Return forward compatible stable string describing this url.


### PR DESCRIPTION
Fix a crash on a system without 'unzip':
```
Traceback (most recent call last):
  File "/bob/pym/bob/scripts.py", line 146, in catchErrors
    ret = fun(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^
  File "/bob/pym/bob/scripts.py", line 254, in cmd
    ret = cmd(args.args, bobRoot)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/bob/pym/bob/scripts.py", line 29, in __develop
    doDevelop(*args, **kwargs)
  File "/bob/pym/bob/cmds/build/build.py", line 410, in doDevelop
    commonBuildDevelop(parser, argv, bobRoot, True)
  File "/bob/pym/bob/cmds/build/build.py", line 345, in commonBuildDevelop
    builder.cook([ExecutableStep.fromStep(b, LazyIR) for b in backlog],
  File "/bob/pym/bob/builder.py", line 916, in cook
    raise self.__buildErrors[0]
  File "/bob/pym/bob/builder.py", line 811, in __taskWrapper
    ret = await coro()
          ^^^^^^^^^^^^
  File "/bob/pym/bob/builder.py", line 970, in _cookStep
    await self._cookCheckoutStep(step, depth)
  File "/bob/pym/bob/builder.py", line 1173, in _cookCheckoutStep
    await self._runShell(checkoutStep, "checkout", a)
  File "/bob/pym/bob/builder.py", line 737, in _runShell
    ret = await invoker.executeStep(mode, cleanWorkspace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/bob/pym/bob/invoker.py", line 379, in executeStep
    await scm.invoke(self)
  File "/bob/pym/bob/scm/url.py", line 371, in invoke
    executor.fail("No suitable extractor found!")
    ^^^^^^^^
NameError: name 'executor' is not defined
```