### PR TITLE
intermediate: support colon seperated tool paths

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -558,7 +558,8 @@ automatically:
   ``${BOB_DEP_PATHS[libfoo-dev]}``) instead of the position (e.g. ``$2``).
 * ``BOB_TOOL_PATHS``: An associative array that holds the execution paths to
   consumed tools indexed by the package name. All these paths are in ``$PATH``
-  resp. ``%PATH%``.
+  resp. ``%PATH%``. If a tool requires more than one path each path is added
+  separately with a incrementing counter appended to the package name.
 
 The associative arrays are no regular environment variables. Hence they are not
 inherited by other processes that are invoked by the executed scripts. In bash
@@ -1619,10 +1620,11 @@ consuming recipes. Example::
          fingerprintScript: |
             bob-libc-version gcc
 
-The ``path`` attribute is always needed.  The ``libs`` attribute, if present,
-must be a list of paths to needed shared libraries. Any path that is specified
-must be relative. If the recipe makes use of existing host binaries and wants
-to provide them as tool you should create symlinks to the host paths.
+The ``path`` attribute is always needed. It might be a single path or a colon
+separated list of paths. The ``libs`` attribute, if present, must be a list of
+paths to needed shared libraries. Any path that is specified must be relative.
+If the recipe makes use of existing host binaries and wants to provide them as
+tool you should create symlinks to the host paths.
 
 The ``netAccess`` attribute allows the tool to request network access during
 build/package step execution even if the recipe has not requested it (see

--- a/pym/bob/intermediate.py
+++ b/pym/bob/intermediate.py
@@ -225,8 +225,8 @@ class StepIR(AbstractIR):
         The returned list is intended to be passed as PATH environment variable.
         The paths are sorted by name.
         """
-        return sorted([ os.path.join(tool.getStep().getExecPath(self), tool.getPath())
-            for tool in self.getTools().values() ])
+        return sorted([ os.path.join(tool.getStep().getExecPath(self), p)
+            for tool in self.getTools().values() for p in tool.getPath().split(':') ])
 
     def getLibraryPaths(self):
         """Get sorted list of library paths of used tools.

--- a/pym/bob/languages.py
+++ b/pym/bob/languages.py
@@ -688,8 +688,8 @@ class StepSpec:
                 for a in step.getArguments() if a.isValid()
             ]),
             'toolPaths' : sorted([
-                (n, os.path.join(t.getStep().getExecPath(step), t.getPath()))
-                for (n,t) in step.getTools().items()
+                (n if i == 0 else n + str(i), os.path.join(t.getStep().getExecPath(step), p))
+                for (n,t) in step.getTools().items() for i, p in enumerate(t.getPath().split(':'))
             ]),
         }
 

--- a/test/black-box/tools-paths/recipes/root.yaml
+++ b/test/black-box/tools-paths/recipes/root.yaml
@@ -1,0 +1,10 @@
+root: True
+
+depends:
+  - name: tools
+    use: [tools]
+
+packageTools: [foo_bar]
+packageScript: |
+  foo.sh
+  bar.sh

--- a/test/black-box/tools-paths/recipes/tools.yaml
+++ b/test/black-box/tools-paths/recipes/tools.yaml
@@ -1,0 +1,16 @@
+packageScript: |
+  mkdir -p foo bar
+  for i in foo bar; do
+    pushd $i
+    cat > $i.sh << EOF
+  #!/bin/bash
+  echo "Hello $i"
+  EOF
+    chmod +x $i.sh
+    popd
+  done
+
+provideTools:
+  foo_bar:
+    path: "foo:bar"
+

--- a/test/black-box/tools-paths/run.sh
+++ b/test/black-box/tools-paths/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+. ../../test-lib.sh 2>/dev/null || { echo "Must run in script directory!" ; exit 1 ; }
+
+# Tests the different aspects of tool remapping for dependencies.
+
+exec_blackbox_test


### PR DESCRIPTION
Make it possible to define tools with more than one directory containing executables by handling colons in path as separator.