### PR TITLE
support converting relative paths in environment variables to absolut…

### DIFF
--- a/pym/bob/intermediate.py
+++ b/pym/bob/intermediate.py
@@ -216,7 +216,12 @@ class StepIR(AbstractIR):
                     self.__data['allDepSteps'][1 if forceSandbox else 0] ]
 
     def getEnv(self):
-        return self.__data['env']
+        envs = dict(self.__data['env'])
+        for (name, tool) in sorted(self.getTools().items()):
+            for(key, value) in tool.getEnv().items():
+                if (key in envs) and (value.startswith(("./", "../"))):
+                    envs[key] = os.path.join(tool.getStep().getExecPath(self), value)
+        return envs
 
     def getPaths(self):
         # FIXME: rename to getToolPaths
@@ -495,6 +500,7 @@ class ToolIR(AbstractIR):
         self.__data['step'] = graph.addStep(tool.getStep(), True)
         self.__data['path'] = tool.getPath()
         self.__data['libs'] = tool.getLibs()
+        self.__data['envs'] = tool.getEnvironment()
         return self
 
     @classmethod
@@ -514,6 +520,9 @@ class ToolIR(AbstractIR):
 
     def getLibs(self):
         return self.__data['libs']
+
+    def getEnv(self):
+        return self.__data['envs']
 
 class RecipeIR(AbstractIR):
     @classmethod


### PR DESCRIPTION
In some cross-compilation scenarios, the cross-compiler relies on custom environment variables to specify the path of the compiler. e.g.  QNX_HOST and QNX_TARGET