### PR TITLE
Fix audit execution

### DIFF
--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -1753,14 +1753,14 @@ cd {ROOT}
                                       step, False, self.__buildIdTasks, False)
                 for step in steps
             ]
-            ret = await self.__yieldJobWhile(gatherTasks(tasks), True)
+            ret = await self.__yieldJobWhile(gatherTasks(tasks))
         else:
             tasks = []
             for step in steps:
                 task = self.__createCookTask(lambda s=step: self.__getBuildIdTask(s, depth),
                                              step, False, self.__buildIdTasks, False)
                 tasks.append(task)
-                await self.__yieldJobWhile(asyncio.wait({task}), True)
+                await self.__yieldJobWhile(asyncio.wait({task}))
             # retrieve results as last step to --keep-going
             ret = [ t.result() for t in tasks ]
         return ret
@@ -1842,7 +1842,7 @@ cd {ROOT}
 
         return await step.getDigestCoro(lambda x: getStoredVId(x))
 
-    async def __yieldJobWhile(self, coro, ignoreExecutionStop = False):
+    async def __yieldJobWhile(self, coro):
         """Yield the job slot while waiting for a coroutine.
 
         Handles the dirty details of cancellation. Might throw CancelledError
@@ -1859,7 +1859,7 @@ cd {ROOT}
                     acquired = True
                 except asyncio.CancelledError:
                     pass
-        if not self.__running and not ignoreExecutionStop: raise CancelBuildException
+        if not self.__running: raise CancelBuildException
         return ret
 
     async def _getFingerprint(self, step, depth):
@@ -1899,7 +1899,7 @@ cd {ROOT}
                 fingerprintTask = self.__createFingerprintTask(
                     lambda: self.__calcFingerprintTask(step, sandbox, key, depth),
                     step, key)
-                await self.__yieldJobWhile(asyncio.wait({fingerprintTask}), True)
+                await self.__yieldJobWhile(asyncio.wait({fingerprintTask}))
                 fingerprint = fingerprintTask.result()
         else:
             fingerprint = b''

--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -1068,7 +1068,7 @@ cd {ROOT}
                         if not self._wasAlreadyRun(step, checkoutOnly):
                             if not checkoutOnly:
                                 built, audit = await self._cookPackageStep(step,
-                                    depth, mayUpOrDownload, buildId)
+                                    depth, buildId)
                             self._setAlreadyRun(step, False, checkoutOnly)
 
                 # Upload package if it was built. On Jenkins we always upload
@@ -1550,7 +1550,7 @@ cd {ROOT}
 
         return wasDownloaded, audit
 
-    async def _cookPackageStep(self, packageStep, depth, mayUpOrDownload, packageBuildId):
+    async def _cookPackageStep(self, packageStep, depth, packageBuildId):
         # Dissect input parameters that lead to current workspace the last time
         (prettyPackagePath, created) = self._constructDir(packageStep, "dist")
         oldWasDownloaded, oldWasShared, oldInputHashes, oldInputBuildId = \

--- a/pym/bob/tty.py
+++ b/pym/bob/tty.py
@@ -88,6 +88,7 @@ class WarnOnce(Warn):
 ###############################################################################
 
 class BaseTUIAction:
+    visible = True
 
     def __init__(self, showDetails):
         self.showDetails = showDetails
@@ -136,6 +137,8 @@ class BaseTUI:
             return (low <= self.__verbosity) and (self.__verbosity <= high)
 
 class DummyTUIAction(BaseTUIAction):
+    visible = False
+
     def __init__(self):
         super().__init__(3)
 


### PR DESCRIPTION
Don't delay the execution of audits to finish jobs as soon as possible when the build/package script has returned. Also include the audit into a visible action so that the user knows the build/package step has not finished yet.

Fixes #539 