### PR TITLE
builder: pass process error code to BuildError

### DIFF
--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -787,7 +787,8 @@ cd {ROOT}
                 logger.setError(invoker.getStdio().strip())
             raise BuildError("{} returned with {}"
                                 .format(absRunFile, ret),
-                             help="You may resume at this point with '--resume' after fixing the error.")
+                             help="You may resume at this point with '--resume' after fixing the error.",
+                             returncode=ret)
 
     def getStatistic(self):
         return self.__statistic


### PR DESCRIPTION
This change shall enable Bob to return a process error code in an invoked process to the caller of a Bob command, e.g. `bob dev test`.

Afterwards, it shall be possible to evaluate the returned error code with `echo $?`, which currently always returns `1`.