### PR TITLE
Let sandbox supports custom user information settings

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1750,6 +1750,13 @@ variables. See :ref:`configuration-principle-subst` for the available
 substations. The mount paths are also subject to an additional variable
 expansion when a step using the sandbox *is actually executed*. This can be
 useful e.g. to expand variables that are only available on the build server.
+
+By default, the user ID inside the sandbox is ``nobody``. The optional ``user``
+key allows to use two other identities: ``root`` or ``$USER``.  Note that using
+``root`` does not provide any more privileges. It merely maps the current user
+ID to the root user ID inside the sandbox. The ``$USER`` option keeps the
+current user ID when entering the sandbox. No other values are allowed.
+
 Example::
 
     provideSandbox:
@@ -1761,6 +1768,7 @@ Example::
             - ["\\$SSH_AUTH_SOCK", "\\SSH_AUTH_SOCK", [nofail, nojenkins]]
         environment:
             AUTOCONF_BUILD: "x86_64-linux-gnu"
+        user: nobody
 
 The example assumes that the variable ``MYREPO`` was set somewhere in the
 recipes. On the other hand ``$HOME`` is expanded later at build time. This is
@@ -1777,7 +1785,8 @@ in the :ref:`configuration-config-whitelist` to be available to the shell.
     packages) nor will binary artifacts be re-fetched.
 
 The user might amend the mount and search paths in ``default.yaml`` by a
-:ref:`configuration-config-sandbox` entry.
+:ref:`configuration-config-sandbox` entry. The user identity can be overridden
+too.
 
 .. _configuration-recipes-relocatable:
 
@@ -2390,10 +2399,10 @@ sandbox
 
 Type: Sandbox-Dictionary
 
-The default paths and mounts of a sandbox are defined by the
+The default paths, mounts and user identity inside a sandbox are defined by the
 :ref:`configuration-recipes-provideSandbox` keyword. The ``sandbox`` section in
-the user configuration allows to specify additional mounts and additional
-search paths. The format of the settings is the same as in the
+the user configuration allows to specify additional mounts, search paths or
+override the user identity. The format of the settings is the same as in the
 :ref:`configuration-recipes-provideSandbox` keyword.
 
 Example::
@@ -2403,6 +2412,7 @@ Example::
             - [ "$HOME/bin", "/mnt" ]
         paths:
             - /mnt
+        user: "$USER"
 
 The search paths from ``paths`` are added to ``$PATH`` in reverse order so that
 later entries have a higher precedence. In contrast to ``provideSandbox`` *no*
@@ -2410,10 +2420,17 @@ variable substitution is possible for the mounts. The mount paths are still subj
 shell variable expansion when a step using the sandbox *is actually executed*,
 though.
 
+The ``user`` key allows to override the user identity inside the sandbox. It
+takes precedence over the value specified in
+:ref:`configuration-recipes-provideSandbox`. The default is ``nobody`` if
+neither setting is given. Other possible values are ``root`` and ``$USER``.
+The latter is replaced by the current user ID. No other values are allowed.
+
 The example above will mount the ``bin`` directory of the users home directory
 as ``/mnt`` inside the sandbox. The ``/mnt`` directory will be in ``$PATH``
 before any other search directory of the sandbox but still after any used tool
-(if any).
+(if any). Additionally, the user identity inside the sandbox will be the same
+as the current user.
 
 .. _configuration-config-scmDefaults:
 

--- a/pym/bob/intermediate.py
+++ b/pym/bob/intermediate.py
@@ -448,6 +448,7 @@ class SandboxIR(AbstractIR):
         self.__data['step'] = graph.addStep(sandbox.getStep(), True)
         self.__data['paths'] = sandbox.getPaths()
         self.__data['mounts'] = sandbox.getMounts()
+        self.__data['user'] = sandbox.getUser()
         return self
 
     @classmethod
@@ -467,6 +468,9 @@ class SandboxIR(AbstractIR):
 
     def getMounts(self):
         return self.__data['mounts']
+
+    def getUser(self):
+        return self.__data['user']
 
 class ToolIR(AbstractIR):
     @classmethod

--- a/pym/bob/invoker.py
+++ b/pym/bob/invoker.py
@@ -294,6 +294,13 @@ class Invoker:
             elif hostPath != sndbxPath:
                 cmdArgs.extend(["-m", sndbxPath])
 
+        if self.__spec.sandboxUser == "root":
+            cmdArgs.append("-r")
+        elif self.__spec.sandboxUser == "$USER":
+            cmdArgs.append("-i")
+        else:
+            assert self.__spec.sandboxUser == "nobody"
+
         return cmdArgs
 
     async def executeStep(self, mode, clean=False, keepSandbox=False):

--- a/pym/bob/languages.py
+++ b/pym/bob/languages.py
@@ -713,6 +713,7 @@ class StepSpec:
                 'root' : step.getSandbox().getStep().getStoragePath(),
                 'paths' : step.getSandbox().getPaths(),
                 'hostMounts' : step.getSandbox().getMounts(),
+                'user' : step.getSandbox().getUser(),
                 'netAccess' : step.hasNetAccess(),
                 'depMounts' : [
                     (dep.getStoragePath(), dep.getExecPath(step))
@@ -803,6 +804,10 @@ class StepSpec:
     @property
     def sandboxPaths(self):
         return self.__data['sandbox']['paths']
+
+    @property
+    def sandboxUser(self):
+        return self.__data['sandbox']['user']
 
     @property
     def envWhiteList(self):

--- a/test/black-box/sandbox/as-root.yaml
+++ b/test/black-box/sandbox/as-root.yaml
@@ -1,0 +1,2 @@
+sandbox:
+    user: "root"

--- a/test/black-box/sandbox/as-self.yaml
+++ b/test/black-box/sandbox/as-self.yaml
@@ -1,0 +1,2 @@
+sandbox:
+    user: "$USER"

--- a/test/black-box/sandbox/recipes/root.yaml
+++ b/test/black-box/sandbox/recipes/root.yaml
@@ -9,7 +9,8 @@ checkoutScript: |
     echo ok
 buildScript: |
     echo ok
-packageVars: [FOO]
+packageVars: [FOO, EXPECT_UID]
 packageScript: |
     test $FOO = bar
+    test ${EXPECT_UID:-65534} = $UID
     echo ok

--- a/test/black-box/sandbox/run.sh
+++ b/test/black-box/sandbox/run.sh
@@ -10,3 +10,7 @@ cleanup
 
 run_bob build -DFOO=bar root
 run_bob dev --sandbox -E root
+
+# Check that we can keep our UID or even be root inside sandbox
+run_bob dev --sandbox -c as-self -DEXPECT_UID=$UID root
+run_bob dev --sandbox -c as-root -DEXPECT_UID=0 root


### PR DESCRIPTION
 This patch is used to address the issue of needing to use a specific user ID during the compilation phase to connect to the server and validate the compiler license legality, e.g. QNX project qcc compiler need to check license via online server