### PR TITLE
input: add 'inherit' dependency property

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1291,6 +1291,16 @@ The following settings are supported:
 |             |                 | At the dependency both names will refer to the same |
 |             |                 | tool.                                               |
 +-------------+-----------------+-----------------------------------------------------+
+| inherit     | Boolean         | Inherit current environment, tools and sandbox to   |
+|             |                 | this dependency. When set to ``false``, all         |
+|             |                 | environment variables are reset to their default    |
+|             |                 | and no tools or sandbox are passed down to the      |
+|             |                 | dependency. This is mostly useful to make an        |
+|             |                 | existing root-package become a dependency of        |
+|             |                 | another (root) package.                             |
+|             |                 |                                                     |
+|             |                 | Default: ``true``                                   |
++-------------+-----------------+-----------------------------------------------------+
 
 .. _configuration-recipes-env:
 


### PR DESCRIPTION
This property controls the inheritance of environment, tools and sandbox
for a dependency. It defaults to true so everything is inherited.

If set to `false` environment, tools and sandbox are dropped. The
dependency starts with the default-environment, no tools and no sandbox.

This becomes particularly useful when an existing root-package should
become a dependency of another root-package, e.g. for building an
installer.