### PR TITLE
builder: consider all execution paths

### DIFF
--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -1295,7 +1295,7 @@ cd {ROOT}
         # dependency directories change.
         buildVariantId = await self.__getIncrementalVariantId(buildStep)
         buildDigest = [buildVariantId, buildStep.getExecPath()] + \
-            [ i.getExecPath(buildStep) for i in buildStep.getArguments() if i.isValid() ]
+            [ i.getExecPath(buildStep) for i in buildStep.getAllDepSteps() if i.isValid() ]
 
         # get directory into shape
         (prettyBuildPath, created) = self._constructDir(buildStep, "build")


### PR DESCRIPTION
The builds step implicitly depends on the execution path of all dependencies, even for tools.