### PR TITLE
input: apply env substition to checkoutAssert

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -793,6 +793,8 @@ Line numbers start at 1 and are inclusive. The ``start`` line is always taken
 into account even if the ``end`` line is equal or smaller. The line terminator
 is always ``\n`` (ASCII "LF", 0x0a) regardless of the host operating system.
 
+String substitution is applied to every setting.
+
 Example::
 
     checkoutAssert:

--- a/test/black-box/checkoutAssert/recipes/root.yaml
+++ b/test/black-box/checkoutAssert/recipes/root.yaml
@@ -6,9 +6,9 @@ checkoutScript: |
 checkoutAssert:
     - 
       file: gpl3.txt
-      start: 1 
+      start: "${GPL3_START}"
       end: 4
-      digestSHA1: 158b94393dfdad277ff26017663c1c56676aaa84
+      digestSHA1: "${GPL3_1_4_SHA1}"
     - 
       file: gpl3.txt
       digestSHA1: 08481bca10b37e1d13d9163515522f774c262cdb

--- a/test/black-box/checkoutAssert/run.sh
+++ b/test/black-box/checkoutAssert/run.sh
@@ -3,7 +3,7 @@
 cleanup
 
 # checkoutAssert shouldn't trigger in this test
-run_bob dev root
+run_bob dev root -DGPL3_START=1 -DGPL3_1_4_SHA1=158b94393dfdad277ff26017663c1c56676aaa84
 
 # checkoutAssert should make the build fail in this test
 expect_fail run_bob dev root_fail


### PR DESCRIPTION
If variables are used to control the checkout of a package the checkoutAssert might need to be variable as well.