### PR TITLE
show: fix crash with checkoutAssert

### DIFF
--- a/pym/bob/cmds/show.py
+++ b/pym/bob/cmds/show.py
@@ -50,7 +50,7 @@ def dumpPackage(package):
             for s in checkoutStep.getScmList()
         ]
         doc["checkoutAssert"] = [
-            { k:v for k,v in a.getProperties().items() if not k.startswith("__") }
+            { k:v for k,v in a.items() if not k.startswith("__") }
             for a in recipe.checkoutAsserts
         ]
         doc["checkoutTools"] = {

--- a/test/black-box/show/recipes/dep.yaml
+++ b/test/black-box/show/recipes/dep.yaml
@@ -1,2 +1,9 @@
+checkoutScript: |
+    echo "foo" > test
+
+checkoutAssert:
+    - file: test
+      digestSHA1: f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+
 packageScript: |
     some dependency


### PR DESCRIPTION
Fix a regression of 0c40313b:

     File "pym/bob/cmds/show.py", line 54, in <listcomp>
       { k:v for k,v in a.getProperties().items() if not k.startswith("__") }
                        ^^^^^^^^^^^^^^^
   AttributeError: 'dict' object has no attribute 'getProperties'

and add a test for this.