### PR TITLE
github: use upload token for coverage

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,9 @@ jobs:
             - name: Upload coverage to Codecov
               # Coverage is not complete on Python <3.7 (see pym/bob/utils.py)
               if: matrix.python-version != '3.6'
-              uses: codecov/codecov-action@v2
+              uses: codecov/codecov-action@v4
+              with:
+                token: ${{ secrets.CODECOV_TOKEN }}
 
             - name: Store the binary wheel
               uses: actions/upload-artifact@v3
@@ -90,7 +92,9 @@ jobs:
                 bash ./test/run-tests.sh -c xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v2
+              uses: codecov/codecov-action@v4
+              with:
+                token: ${{ secrets.CODECOV_TOKEN }}
 
     build-sdist:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This won't resolve the failed coverage uploads on pull requests, though. But main repository builds should become stable and always update the coverage.