### PR TITLE
scripts: set cmd line color mode immediately

### DIFF
--- a/pym/bob/scripts.py
+++ b/pym/bob/scripts.py
@@ -215,6 +215,7 @@ def bob(bobRoot = None):
         if args.color_mode:
             from .input import RecipeSet
             RecipeSet.setColorModeCfg(args.color_mode)
+            setColorMode(args.color_mode)
 
         if args.query_mode:
             from .input import RecipeSet


### PR DESCRIPTION
If the user gives a color mode on the command line, apply the mode immediately. Otherwise the mode was not applied until some recipes layer was successfully parsed. Because error messages are already colored, that created some inconsistent behaviour.

Fixes #578.