### PR TITLE
Fix variable substitutions with unused parts

### DIFF
--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -88,6 +88,7 @@ class StringParser:
         return "".join(tok)
 
     def getRestOfName(self):
+        """Get remainder of bare variable name"""
         ret = ''
         i = self.index
         while i < self.end:
@@ -100,6 +101,7 @@ class StringParser:
         return ret
 
     def getSingleQuoted(self):
+        """Get remainder of single quoted string."""
         i = self.index
         while i < self.end:
             if self.text[i] == "'":
@@ -112,6 +114,15 @@ class StringParser:
         return ret
 
     def getString(self, delim=[None], keep=False):
+        """Interpret as string from current parsing position.
+
+        Do any necessary substitutions until either the string ends or hits one
+        of the additional delimiters.
+
+        :param delim: Additional delimiter characters where parsing should stop
+        :param keep: Keep the additional delimiter if hit. By default the
+                     delimier is swallowed.
+        """
         s = []
         tok = self.nextToken(delim)
         while tok not in delim:
@@ -141,6 +152,7 @@ class StringParser:
         return "".join(s)
 
     def getVariable(self):
+        """Substitute variable at current position."""
         # get variable name
         varName = self.getString([':', '-', '+', '}'], True)
 
@@ -175,6 +187,10 @@ class StringParser:
             raise ParseError("Unterminated variable: " + str(op))
 
     def getBareVariable(self, varName):
+        """Substitute base variable at current position.
+
+        :param varName: Initial character of variable name
+        """
         varName += self.getRestOfName()
         varValue = self.env.get(varName)
         if varValue is None:
@@ -185,6 +201,7 @@ class StringParser:
             return varValue
 
     def getCommand(self):
+        """Substitute string function at current position."""
         words = []
         delim = [",", ")"]
         while True:

--- a/pym/bob/stringparser.py
+++ b/pym/bob/stringparser.py
@@ -33,6 +33,8 @@ def isTrue(val):
 class StringParser:
     """Utility class for complex string parsing/manipulation"""
 
+    __slots__ = ('env', 'funs', 'funArgs', 'nounset', 'text', 'index', 'end')
+
     def __init__(self, env, funs, funArgs, nounset):
         self.env = env
         self.funs = funs

--- a/test/unit/test_input_stringparser.py
+++ b/test/unit/test_input_stringparser.py
@@ -119,6 +119,26 @@ class TestStringParser(TestCase):
         self.assertRaises(ParseError, u.parse, "$1")
         self.assertRaises(ParseError, u.parse, "$%%")
 
+    def testSkipUnused(self):
+        """Unused branches must not be substituted.
+
+        Syntax error must still be detected, though.
+        """
+
+        self.assertEqual(self.p.parse("${asdf:-$unset}"), "qwer")
+        self.assertEqual(self.p.parse("${asdf:-${unset}}"), "qwer")
+        self.assertEqual(self.p.parse("${asdf:-${${double-unset}}}"), "qwer")
+        self.assertEqual(self.p.parse("${asdf:-$(unknown)}"), "qwer")
+        self.assertEqual(self.p.parse("${asdf:-$($fn,$unset)}"), "qwer")
+        self.assertRaises(ParseError, self.p.parse, "${asdf:-$($fn}")
+
+        self.assertEqual(self.p.parse("${unset:+$unset}"), "")
+        self.assertEqual(self.p.parse("${unset:+${unset}}"), "")
+        self.assertEqual(self.p.parse("${unset:+${${double-unset}}}"), "")
+        self.assertEqual(self.p.parse("${unset:+$(unknown)}"), "")
+        self.assertEqual(self.p.parse("${unset:+$($fn,$unset)}"), "")
+        self.assertRaises(ParseError, self.p.parse, "${unset:+${${double-unset}}")
+
 class TestStringFunctions(TestCase):
 
     def testEqual(self):


### PR DESCRIPTION
Fix constructs like `${VAR:+${VAR}}` that fail so far.