### PR TITLE
git: do not move detached HEAD to attic if same commit

### DIFF
--- a/pym/bob/scm/git.py
+++ b/pym/bob/scm/git.py
@@ -598,7 +598,7 @@ class GitScm(Scm):
 
             curCommit = await invoker.checkOutputCommand(["git", "rev-parse",
                 "HEAD"], cwd=self.__dir)
-            if curCommit != oldCommit:
+            if curCommit != oldCommit and curCommit != self.__commit:
                 invoker.fail("Cannot switch: user moved to different commit: {} vs. {}".format(curCommit, oldCommit))
 
         # Try to checkout new state in old workspace. If something fails the


### PR DESCRIPTION
If a git-workspace is in a detached HEAD state and the recipe has been updated to point to the same commit there is no need to move this into attic.