### PR TITLE
build: add bundle build

### DIFF
--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -118,7 +118,7 @@ __bob_clean()
 
 __bob_cook()
 {
-   if [[ "$prev" = "--destination" ]] ; then
+   if [[ "$prev" = "--destination" || "$prev" == "--bundle" ]] ; then
       __bob_complete_dir "$cur"
    elif [[ "$prev" = "--download" ]] ; then
          __bob_complete_words "yes no deps forced forced-deps forced-fallback"
@@ -127,7 +127,7 @@ __bob_cook()
    elif [[ "$prev" = "--always-checkout" ]] ; then
       COMPREPLY=( )
    else
-      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --clean-checkout --attic --no-attic"
+      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --clean-checkout --attic --no-attic --bundle --bundle-exclude"
    fi
 }
 

--- a/doc/manpages/bob-build-dev.rst
+++ b/doc/manpages/bob-build-dev.rst
@@ -35,6 +35,16 @@ Options
 
     This is the default unless the user changed it in ``default.yaml``.
 
+``--bundle BUNDLE``
+    Bundle all the sources needed to build the package. The bunlde is a tar-file
+    containing the sources and a overrides file. To use the bundle call bob
+    dev/build with ``-c`` pointing to the scmOverrides-file. In addition to this
+    the ``LOCAL_BUNDLE_BASE`` environment variable needs to be set to point to
+    the base-directoy where the bundle has been extracted.
+
+``--bundle-exclude RE``
+    Do not add packages matching  RE to the bundle.
+
 ``--clean``
     Do clean builds by clearing the build directory before executing the build
     commands. It will *not* clean all build results (e.g. like ``make clean``)

--- a/doc/manpages/bob-build.rst
+++ b/doc/manpages/bob-build.rst
@@ -24,6 +24,7 @@ Synopsis
               [--shared | --no-shared] [--install | --no-install]
               [--sandbox | --no-sandbox] [--clean-checkout]
               [--attic | --no-attic]
+              [--bundle BUNDLE] [--bundle-exclude BUNDLE_EXCLUDE]
               PACKAGE [PACKAGE ...]
 
 

--- a/doc/manpages/bob-dev.rst
+++ b/doc/manpages/bob-dev.rst
@@ -24,6 +24,7 @@ Synopsis
             [--shared | --no-shared] [--install | --no-install]
             [--sandbox | --no-sandbox] [--clean-checkout]
             [--attic | --no-attic]
+            [--bundle BUNDLE] [--bundle-exclude BUNDLE_EXCLUDE]
             PACKAGE [PACKAGE ...]
 
 

--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -211,6 +211,10 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         help="Move scm to attic if inline switch is not possible (default).")
     group.add_argument('--no-attic', action='store_false', default=None, dest='attic',
         help="Do not move to attic, instead fail the build.")
+    parser.add_argument('--bundle', metavar='BUNDLE', default=None,
+        help="Bundle all matching packages to BUNDLE")
+    parser.add_argument('--bundle-exclude', action='append', default=[],
+        help="Do not add matching packages to bundle.")
     args = parser.parse_args(argv)
 
     defines = processDefines(args.defines)
@@ -296,6 +300,9 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         packages = recipes.generatePackages(nameFormatter, args.sandbox)
         if develop: developPersister.prime(packages)
 
+        if args.bundle and args.build_mode == 'build-only':
+            parser.error("--bundle can't be used with --build-only")
+
         verbosity = cfg.get('verbosity', 0) + args.verbose - args.quiet
         setVerbosity(verbosity)
         builder = LocalBuilder(verbosity, args.force,
@@ -319,6 +326,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         builder.setShareHandler(getShare(recipes.getShareConfig()))
         builder.setShareMode(args.shared, args.install)
         builder.setAtticEnable(args.attic)
+        builder.setBundle(args.bundle, args.bundle_exclude)
         if args.resume: builder.loadBuildState()
 
         backlog = []
@@ -379,6 +387,8 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
                 + str(stats.packagesBuilt)
                     + " package" + ("s" if (stats.packagesBuilt != 1) else "") + " built, "
                 + str(stats.packagesDownloaded) + " downloaded.")
+
+        builder.bundle()
 
         # Copy build result if requested. It's ok to overwrite files that are
         # already at the destination. Warn if built packages overwrite

--- a/pym/bob/scm/cvs.py
+++ b/pym/bob/scm/cvs.py
@@ -46,7 +46,9 @@ class CvsScm(Scm):
         })
         return ret
 
-    async def invoke(self, invoker):
+    async def invoke(self, invoker, bundleFile=None):
+        if bundleFile is not None:
+            invoker.fail("Bundling of an cvs scm is not implemented!")
         # If given a ":ssh:" cvsroot, translate that to CVS_RSH using ssh, and ":ext:"
         # (some versions of CVS do that internally)
         m = re.match('^:ssh:(.*)', self.__cvsroot)

--- a/pym/bob/scm/imp.py
+++ b/pym/bob/scm/imp.py
@@ -149,7 +149,10 @@ class ImportScm(Scm):
             ret['__projectRoot'] = self.__projectRoot
         return ret
 
-    async def invoke(self, invoker):
+    async def invoke(self, invoker, bundleFile=None):
+        if bundleFile is not None:
+            invoker.fail("Bundling of an import scm is not implemented!")
+
         dest = invoker.joinPath(self.__dir)
         os.makedirs(dest, exist_ok=True)
         if self.__prune: emptyDirectory(dest)

--- a/pym/bob/scm/svn.py
+++ b/pym/bob/scm/svn.py
@@ -49,7 +49,10 @@ class SvnScm(Scm):
             ret["revision"] = self.__revision
         return ret
 
-    async def invoke(self, invoker):
+    async def invoke(self, invoker, bundleFile=None):
+        if bundleFile is not None:
+            invoker.fail("Bundling of an svn scm is not implemented!")
+
         options = [ "--non-interactive" ]
         if not self.__sslVerify:
             options += [ "--trust-server-cert-failures=unknown-ca,cn-mismatch,expired,not-yet-valid,other" ]

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -285,6 +285,10 @@ class UrlScm(Scm):
         })
         return ret
 
+    @property
+    def bundleName(self):
+        return os.path.join(self.__dir, os.path.basename(urllib.parse.urlparse(self.__url).path))
+
     def __applyMirrors(self, mirrors):
         if not self.isDeterministic():
             return []
@@ -535,7 +539,7 @@ class UrlScm(Scm):
         # does not match.
         return True
 
-    async def invoke(self, invoker):
+    async def invoke(self, invoker, bundleFile=None):
         os.makedirs(invoker.joinPath(self.__dir), exist_ok=True)
         workspaceFile = os.path.join(self.__dir, self.__fn)
         destination = invoker.joinPath(self.__dir, self.__fn)
@@ -578,6 +582,10 @@ class UrlScm(Scm):
             d = hashFile(destination, hashlib.sha512).hex()
             if d != self.__digestSha512:
                 invoker.fail("SHA512 digest did not match! expected:", self.__digestSha512, "got:", d)
+
+        if bundleFile is not None:
+            os.makedirs(os.path.dirname(bundleFile), exist_ok=True)
+            shutil.copyfile(destination, bundleFile)
 
         # Upload to mirrors that requested it. This is only done for stable
         # files, though.


### PR DESCRIPTION
A bob-bundle collects all scm's neccessary to build a package in a tar-file. Next to the tar-file a scmOverrides file is generated to be able to rebuild the package only with the bundle.

Such a bundle can be used to build on a air-gapped system or to archive all sources of a build.

ATM only bundling of git and url-scm's is supported.