### PR TITLE
Fix some layers inconsistencies

### DIFF
--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -388,12 +388,12 @@ __bob_status()
 
 __bob_layers_status()
 {
-   __bob_complete_path "-c -D -v -lc --attic --no-attic"
+   __bob_complete_words "-D -v -lc --show-clean --show-overrides"
 }
 
 __bob_layers_update()
 {
-   __bob_complete_path "-c -D -v -lc --attic --no-attic"
+   __bob_complete_words "-D -v -lc --attic --no-attic"
 }
 
 __bob_layers()

--- a/doc/manpages/bob-layers.rst
+++ b/doc/manpages/bob-layers.rst
@@ -52,7 +52,8 @@ Options
 
     The ``.yaml`` suffix is appended automatically and the configuration file
     is searched relative to the project root directory unless an absolute path
-    is given.
+    is given. If multiple layer configuration files are passed, all files are
+    parsed. Later files on the command line have higher precedence.
 
 ``-D VAR=VALUE``
     Override default or set environment variable.

--- a/doc/manpages/bob-layers.rst
+++ b/doc/manpages/bob-layers.rst
@@ -15,9 +15,10 @@ Synopsis
 
 ::
 
-    bob layers [-h] [-lc LAYERCONFIG] [-v] [-D DEFINES]
-               [--attic | --no-attic] 
-               {update,status}
+    bob layers status [-h] [-lc LAYERCONFIG] [-D DEFINES] [--show-clean]
+                      [--show-overrides] [-v]
+    bob layers update [-h] [-lc LAYERCONFIG] [-D DEFINES]
+                      [--attic | --no-attic] [-v]
 
 Description
 -----------
@@ -61,6 +62,17 @@ Options
     Sets the variable ``VAR`` to ``VALUE``. This overrides the value possibly
     set by ``default.yaml``, config files passed by ``-c`` or any file that was
     included by either of these files.
+
+``--show-clean``
+    Show the status of a layer even if unmodified. This includes
+    ``--show-overrides``.
+
+``--show-overrides``
+    Show layers that have active :ref:`layersScmOverrides <configuration-config-layersScmOverrides>`
+    (``O``) even if the layer is unchanged. Override information is always
+    displayed if a layer is shown but a ``STATUS`` line is normally only
+    emitted if the SCM was modified. Adding ``-v`` will additionally show the
+    detailed override status.
 
 ``-v, --verbose``
     Increase verbosity (may be specified multiple times)

--- a/doc/manpages/bob-layers.rst
+++ b/doc/manpages/bob-layers.rst
@@ -15,7 +15,7 @@ Synopsis
 
 ::
 
-    bob layers [-h] [-c CONFIGFILE] [-lc LAYERCONFIG] [-v] [-D DEFINES]
+    bob layers [-h] [-lc LAYERCONFIG] [-v] [-D DEFINES]
                [--attic | --no-attic] 
                {update,status}
 
@@ -43,17 +43,6 @@ Options
 ``--no-attic``
     Do not move layer workspace to attic if inline SCM switching is not possible.
     Instead a build error is issued.
-
-``-c CONFIGFILE``
-    Use additional configuration file.
-
-    The ``.yaml`` suffix is appended automatically and the configuration file
-    is searched relative to the project root directory unless an absolute path
-    is given. Bob will parse these user configuration files after
-    *default.yaml*. They are using the same schema.
-
-    This option can be given multiple times. The files will be parsed in the
-    order as they appeared on the command line.
 
 ``-lc LAYERCONFIG``
     Use additional layer configuration file.

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1970,6 +1970,11 @@ If a layer SCM specification is given, Bob takes care of the layer management:
 - The ``bob layers`` command can update layers or show their status (see
   :ref:`manpage-layers`).
 
+.. note::
+   SCM backed layers are checked out into the build tree rather than the
+   project root directory. This is important as soon as an out-of-source
+   build tree is used (see :ref:`manpage-bob-init`).
+
 Only git, svn, url and cvs SCMs are supported for layers. Because layers are
 fetched and updated before any :ref:`configuration-config-usr` is parsed, the
 regular ``whitelist`` and ``scmOverrides`` settings are not used.  Instead,

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1981,6 +1981,8 @@ layersWhitelist
 
 Whitelist for layers update only. See :ref:`configuration-config-whitelist`.
 
+.. _configuration-config-layersScmOverrides:
+
 layersScmOverrides
 ~~~~~~~~~~~~~~~~~~
 

--- a/pym/bob/cmds/build/build.py
+++ b/pym/bob/cmds/build/build.py
@@ -238,7 +238,7 @@ def commonBuildDevelop(parser, argv, bobRoot, develop):
         recipes.setConfigFiles(args.configFile)
         if args.build_mode != 'build-only':
             setVerbosity(args.verbose)
-            updateLayers(recipes, loop, defines, args.verbose, args.attic, args.layerConfig)
+            updateLayers(loop, defines, args.verbose, args.attic, args.layerConfig)
         recipes.parse(defines)
 
         # if arguments are not passed on cmdline use them from default.yaml or set to default yalue

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -29,13 +29,11 @@ def doLayers(argv, bobRoot):
     defines = processDefines(args.defines)
 
     with EventLoopWrapper() as (loop, executor):
-        recipes = RecipeSet()
         if args.action == "update":
-            updateLayers(recipes, loop, defines, args.verbose,
+            updateLayers(loop, defines, args.verbose,
                          args.attic, args.layerConfig)
         elif args.action == "status":
-            recipes.parse(defines, noLayers=True)
-            layers = Layers(recipes, loop, defines, args.attic)
+            layers = Layers(loop, defines, args.attic)
             layers.setLayerConfig(args.layerConfig)
             layers.collect(False, args.verbose)
             pp = PackagePrinter(args.verbose, False, False)

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -10,8 +10,6 @@ def doLayers(argv, bobRoot):
     parser = argparse.ArgumentParser(prog="bob layers", description='Handle layers')
     parser.add_argument('action', type=str, choices=['update', 'status'], default="status",
                         help="Action: [update, status]")
-    parser.add_argument('-c', dest="configFile", default=[], action='append',
-        help="Use config File.")
     parser.add_argument('-lc', dest="layerConfig", default=[], action='append',
         help="Additional layer config")
     parser.add_argument('-v', '--verbose', default=NORMAL, action='count',
@@ -32,7 +30,6 @@ def doLayers(argv, bobRoot):
 
     with EventLoopWrapper() as (loop, executor):
         recipes = RecipeSet()
-        recipes.setConfigFiles(args.configFile)
         if args.action == "update":
             updateLayers(recipes, loop, defines, args.verbose,
                          args.attic, args.layerConfig)

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -1,6 +1,5 @@
 import argparse
 
-from ..input import RecipeSet
 from ..layers import Layers, updateLayers
 from ..tty import NORMAL, setVerbosity
 from ..utils import EventLoopWrapper, processDefines

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -6,14 +6,30 @@ from ..tty import NORMAL, setVerbosity
 from ..utils import EventLoopWrapper, processDefines
 from .build.status import PackagePrinter
 
-def doLayers(argv, bobRoot):
-    parser = argparse.ArgumentParser(prog="bob layers", description='Handle layers')
-    parser.add_argument('action', type=str, choices=['update', 'status'], default="status",
-                        help="Action: [update, status]")
+def doLayersStatus(argv):
+    parser = argparse.ArgumentParser(prog="bob layers status", description='Query layers SCM status')
     parser.add_argument('-lc', dest="layerConfig", default=[], action='append',
         help="Additional layer config")
+    parser.add_argument('-D', default=[], action='append', dest="defines",
+        help="Override default environment variable")
     parser.add_argument('-v', '--verbose', default=NORMAL, action='count',
         help="Increase verbosity (may be specified multiple times)")
+
+    args = parser.parse_args(argv)
+    setVerbosity(args.verbose)
+    defines = processDefines(args.defines)
+
+    layers = Layers(defines, False)
+    layers.setLayerConfig(args.layerConfig)
+    layers.collect(None, False, args.verbose)
+    pp = PackagePrinter(args.verbose, False, False)
+    layers.status(pp.show)
+
+
+def doLayersUpdate(argv):
+    parser = argparse.ArgumentParser(prog="bob layers update", description='Update layers SCMs')
+    parser.add_argument('-lc', dest="layerConfig", default=[], action='append',
+        help="Additional layer config")
     parser.add_argument('-D', default=[], action='append', dest="defines",
         help="Override default environment variable")
     group = parser.add_mutually_exclusive_group()
@@ -21,21 +37,26 @@ def doLayers(argv, bobRoot):
         help="Move scm to attic if inline switch is not possible (default).")
     group.add_argument('--no-attic', action='store_false', default=None, dest='attic',
         help="Do not move to attic, instead fail the build.")
+    parser.add_argument('-v', '--verbose', default=NORMAL, action='count',
+        help="Increase verbosity (may be specified multiple times)")
 
     args = parser.parse_args(argv)
-
     setVerbosity(args.verbose)
-
     defines = processDefines(args.defines)
 
     with EventLoopWrapper() as (loop, executor):
-        if args.action == "update":
-            updateLayers(loop, defines, args.verbose,
-                         args.attic, args.layerConfig)
-        elif args.action == "status":
-            layers = Layers(defines, args.attic)
-            layers.setLayerConfig(args.layerConfig)
-            layers.collect(loop, False, args.verbose)
-            pp = PackagePrinter(args.verbose, False, False)
-            layers.status(pp.show)
+        updateLayers(loop, defines, args.verbose, args.attic, args.layerConfig)
 
+
+def doLayers(argv, bobRoot):
+    parser = argparse.ArgumentParser(prog="bob layers", description='Handle layers')
+    parser.add_argument('action', type=str, choices=['update', 'status'],
+                        help="Action: [update, status]")
+    parser.add_argument('args', nargs=argparse.REMAINDER,
+                        help="Arguments for action")
+
+    args = parser.parse_args(argv)
+    if args.action == "status":
+        doLayersStatus(args.args)
+    elif args.action == "update":
+        doLayersUpdate(args.args)

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -12,6 +12,10 @@ def doLayersStatus(argv):
         help="Additional layer config")
     parser.add_argument('-D', default=[], action='append', dest="defines",
         help="Override default environment variable")
+    parser.add_argument('--show-clean', action='store_true',
+        help="Show SCM status even if layer is unmodified")
+    parser.add_argument('--show-overrides', action='store_true',
+        help="Show SCM status if affected by an scmOverrides")
     parser.add_argument('-v', '--verbose', default=NORMAL, action='count',
         help="Increase verbosity (may be specified multiple times)")
 
@@ -22,7 +26,7 @@ def doLayersStatus(argv):
     layers = Layers(defines, False)
     layers.setLayerConfig(args.layerConfig)
     layers.collect(None, False, args.verbose)
-    pp = PackagePrinter(args.verbose, False, False)
+    pp = PackagePrinter(args.verbose, args.show_clean, args.show_overrides)
     layers.status(pp.show)
 
 

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -33,9 +33,9 @@ def doLayers(argv, bobRoot):
             updateLayers(loop, defines, args.verbose,
                          args.attic, args.layerConfig)
         elif args.action == "status":
-            layers = Layers(loop, defines, args.attic)
+            layers = Layers(defines, args.attic)
             layers.setLayerConfig(args.layerConfig)
-            layers.collect(False, args.verbose)
+            layers.collect(loop, False, args.verbose)
             pp = PackagePrinter(args.verbose, False, False)
             layers.status(pp.show)
 

--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -33,13 +33,11 @@ def doLayers(argv, bobRoot):
         if args.action == "update":
             updateLayers(recipes, loop, defines, args.verbose,
                          args.attic, args.layerConfig)
-
-        recipes.parse(defines, noLayers=True)
-
-        layers = Layers(recipes, loop, defines, args.attic)
-        layers.setLayerConfig(args.layerConfig)
-        layers.collect(False, args.verbose)
-        if args.action == "status":
+        elif args.action == "status":
+            recipes.parse(defines, noLayers=True)
+            layers = Layers(recipes, loop, defines, args.attic)
+            layers.setLayerConfig(args.layerConfig)
+            layers.collect(False, args.verbose)
             pp = PackagePrinter(args.verbose, False, False)
             layers.status(pp.show)
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -14,7 +14,7 @@ from .stringparser import checkGlobList, Env, DEFAULT_STRING_FUNS, IfExpression
 from .tty import InfoOnce, Warn, WarnOnce, setColorMode, setParallelTUIThreshold
 from .utils import asHexStr, joinScripts, compareVersion, binStat, \
     updateDicRecursive, hashString, getPlatformTag, getPlatformString, \
-    replacePath
+    replacePath, getPlatformEnvWhiteList
 from itertools import chain
 from os.path import expanduser
 from string import Template
@@ -3465,23 +3465,7 @@ class RecipeSet:
         self.__platform = platform
         self.__layers = []
         self.__policies = RecipeSet.POLICIES.copy()
-        self.__whiteList = set()
-        if platform == 'win32':
-            self.__whiteList |= set(["ALLUSERSPROFILE", "APPDATA",
-                "COMMONPROGRAMFILES", "COMMONPROGRAMFILES(X86)", "COMSPEC",
-                "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
-                "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)", "SYSTEMDRIVE",
-                "SYSTEMROOT", "TEMP", "TMP", "WINDIR"])
-        else:
-            self.__whiteList |= set(["PATH", "TERM", "SHELL", "USER", "HOME"])
-
-        if platform in ('cygwin', 'msys'):
-            self.__whiteList |= set(["ALLUSERSPROFILE", "APPDATA",
-                "COMMONPROGRAMFILES", "CommonProgramFiles(x86)", "COMSPEC",
-                "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
-                "ProgramData", "PROGRAMFILES", "ProgramFiles(x86)", "SYSTEMDRIVE",
-                "SYSTEMROOT", "TEMP", "TMP", "WINDIR"])
-
+        self.__whiteList = getPlatformEnvWhiteList(platform)
         self.__pluginPropDeps = b''
         self.__pluginSettingsDeps = b''
         self.__createSchemas()

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3953,6 +3953,14 @@ class YamlCache:
         self.__files[name] = hashlib.sha1(result).digest()
         return result
 
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
 
 class PackagePickler(pickle.Pickler):
     def __init__(self, file, pathsConfig):

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -1739,13 +1739,6 @@ class LayerSpec:
         return self.__scm
 
 class LayerValidator:
-    def __init__(self):
-        self.__scmValidator = ScmValidator({
-            'git' : GitScm.SCHEMA,
-            'svn' : SvnScm.SCHEMA,
-            'cvs' : CvsScm.SCHEMA,
-            'url' : UrlScm.SCHEMA})
-
     def validate(self, data):
         if isinstance(data,str):
             return LayerSpec(data)
@@ -1755,7 +1748,7 @@ class LayerValidator:
         name = _data.get('name')
         del _data['name']
 
-        return LayerSpec (name, self.__scmValidator.validate(_data)[0])
+        return LayerSpec(name, RecipeSet.LAYERS_SCM_SCHEMA.validate(_data)[0])
 
 class VarDefineValidator:
     def __init__(self, keyword):
@@ -2952,6 +2945,14 @@ class RecipeSet:
             schema.Optional('type') : schema.Or("d3", "dot"),
             schema.Optional('max_depth') : int,
         })
+
+    # We do not support the "import" SCM for layers. It just makes no sense.
+    LAYERS_SCM_SCHEMA = ScmValidator({
+        'git' : GitScm.SCHEMA,
+        'svn' : SvnScm.SCHEMA,
+        'cvs' : CvsScm.SCHEMA,
+        'url' : UrlScm.SCHEMA,
+    })
 
     SCM_SCHEMA = ScmValidator({
         'git' : GitScm.SCHEMA,

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3438,8 +3438,7 @@ class RecipeSet:
     def loadYaml(self, path, schema, default={}, preValidate=lambda x: None):
         return self.__cache.loadYaml(path, schema, default, preValidate)
 
-    def parse(self, envOverrides={}, platform=getPlatformString(), recipesRoot="",
-              noLayers=False):
+    def parse(self, envOverrides={}, platform=getPlatformString(), recipesRoot=""):
         if not recipesRoot and os.path.isfile(".bob-project"):
             try:
                 with open(".bob-project") as f:
@@ -3452,11 +3451,11 @@ class RecipeSet:
         self.__projectRoot = recipesRoot or os.getcwd()
         self.__cache.open()
         try:
-            self.__parse(envOverrides, platform, recipesRoot, noLayers)
+            self.__parse(envOverrides, platform, recipesRoot)
         finally:
             self.__cache.close()
 
-    def __parse(self, envOverrides, platform, recipesRoot="", noLayers=False):
+    def __parse(self, envOverrides, platform, recipesRoot=""):
         if platform not in ('cygwin', 'darwin', 'linux', 'msys', 'win32'):
             raise ParseError("Invalid platform: " + platform)
         self.__platform = platform
@@ -3473,10 +3472,7 @@ class RecipeSet:
                 os.path.join(os.path.expanduser("~"), '.config')), 'bob', 'default.yaml'))
 
         # Begin with root layer
-        self.__parseLayer(LayerSpec(""), "9999", recipesRoot, noLayers)
-
-        if noLayers:
-            return
+        self.__parseLayer(LayerSpec(""), "9999", recipesRoot)
 
         # Out-of-tree builds may have a dedicated default.yaml
         if recipesRoot:
@@ -3552,7 +3548,7 @@ class RecipeSet:
             ret[name] = (behaviour, None)
         return ret
 
-    def __parseLayer(self, layerSpec, maxVer, recipesRoot, noLayers=False):
+    def __parseLayer(self, layerSpec, maxVer, recipesRoot):
         layer = layerSpec.getName()
 
         if layer in self.__layers:
@@ -3581,9 +3577,6 @@ class RecipeSet:
                                         .format("/".join(layer), name))
         else:
             self.__policies = self.calculatePolicies(config)
-
-        if noLayers:
-            return
 
         # First parse any sub-layers. Their settings have a lower precedence
         # and may be overwritten by higher layers.

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3908,7 +3908,7 @@ class YamlCache:
     def getDigest(self):
         return self.__digest
 
-    def loadYaml(self, name, yamlSchema, default, preValidate):
+    def loadYaml(self, name, yamlSchema, default={}, preValidate=lambda x: None):
         try:
             bs = binStat(name) + yamlSchema[1]
             if self.__hot:

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3566,12 +3566,6 @@ class RecipeSet:
         config_spec = {**RecipeSet.STATIC_CONFIG_SCHEMA_SPEC, **RecipeSet.STATIC_CONFIG_LAYER_SPEC}
         config = self.loadYaml(configYaml, (schema.Schema(config_spec), b''),
             preValidate=preValidate)
-
-        # merge settings
-        for (name, value) in sorted([s for s in config.items() if s[0] in self.__settings],
-                                    key=lambda i: self.__settings[i[0]].priority):
-            self.__settings[name].merge(value)
-
         minVer = config.get("bobMinimumVersion", "0.16")
         if compareVersion(maxVer, minVer) < 0:
             raise ParseError("Layer '{}' requires a higher Bob version than root project!"

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3437,10 +3437,7 @@ class RecipeSet:
         return self.__cache.loadBinary(path)
 
     def loadYaml(self, path, schema, default={}, preValidate=lambda x: None):
-        if os.path.exists(path):
-            return self.__cache.loadYaml(path, schema, default, preValidate)
-        else:
-            return schema[0].validate(default)
+        return self.__cache.loadYaml(path, schema, default, preValidate)
 
     def parse(self, envOverrides={}, platform=getPlatformString(), recipesRoot="",
               noLayers=False):
@@ -3943,6 +3940,8 @@ class YamlCache:
         except sqlite3.Error as e:
             raise ParseError("Cannot access cache: " + str(e),
                 help="You probably executed Bob concurrently in the same workspace. Try again later.")
+        except FileNotFoundError:
+            return yamlSchema[0].validate(default)
         except OSError as e:
             raise ParseError("Error loading yaml file: " + str(e))
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2032,7 +2032,7 @@ class Recipe(object):
         self.__layer = layer
 
         sourceName = ("Recipe " if isRecipe else "Class  ") + packageName + (
-            ", layer "+"/".join(layer) if layer else "")
+            ", layer "+ layer if layer else "")
         incHelperBash = IncludeHelper(BashLanguage, recipeSet.loadBinary,
                                       baseDir, packageName, sourceName).resolve
         incHelperPwsh = IncludeHelper(PwshLanguage, recipeSet.loadBinary,
@@ -3567,7 +3567,7 @@ class RecipeSet:
         minVer = config.get("bobMinimumVersion", "0.16")
         if compareVersion(maxVer, minVer) < 0:
             raise ParseError("Layer '{}' requires a higher Bob version than root project!"
-                                .format("/".join(layer)))
+                                .format(layer))
         maxVer = minVer # sub-layers must not have a higher bobMinimumVersion
 
         # Determine policies. The root layer determines the default settings
@@ -3577,7 +3577,7 @@ class RecipeSet:
             for (name, behaviour) in config.get("policies", {}).items():
                 if bool(self.__policies[name][0]) != behaviour:
                     raise ParseError("Layer '{}' requires different behaviour for policy '{}' than root project!"
-                                        .format("/".join(layer), name))
+                                        .format(layer, name))
         else:
             self.__policies = self.calculatePolicies(config)
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3555,7 +3555,10 @@ class RecipeSet:
             return
         self.__layers.append(layer)
 
-        rootDir = os.path.join(recipesRoot, os.path.join("layers", layer) if layer != "" else "")
+        # SCM backed layers are in build dir, regular layers are in project dir.
+        rootDir = recipesRoot if layerSpec.getScm() is None else ""
+        if layer:
+            rootDir = os.path.join(rootDir, "layers", layer)
         if not os.path.isdir(rootDir or "."):
             raise ParseError(f"Layer '{layer}' does not exist!",
                                      help="You probably want to run 'bob layers update' to fetch missing layers.")

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -81,15 +81,14 @@ class LayerStepSpec:
 
 
 class Layer:
-    def __init__(self, name, upperConfig, root, defines, attic, scm=None):
+    def __init__(self, name, upperConfig, defines, attic, scm=None):
         self.__name = name
         self.__upperConfig = upperConfig
-        self.__root = root
         self.__defines = defines
         self.__attic = attic
         self.__scm = scm
         self.__created = False
-        self.__layerDir = os.path.join(root, "layers", name) if len(name) else root
+        self.__layerDir = os.path.join("layers", name) if len(name) else "."
         self.__subLayers = []
 
     async def __checkoutTask(self, verbose):
@@ -188,7 +187,6 @@ class Layer:
                            recipeSet=self.__config)
             self.__subLayers.append(Layer(l.getName(),
                                           self.__config,
-                                          self.__root,
                                           self.__defines,
                                           self.__attic,
                                           layerScm))
@@ -260,7 +258,7 @@ class Layers:
 
                 config = config.derive(yamlCache.loadYaml(c, configSchema))
 
-            rootLayers = Layer("", config, os.getcwd(), self.__defines, self.__attic)
+            rootLayers = Layer("", config, self.__defines, self.__attic)
             rootLayers.parse(yamlCache)
             self.__layers[0] = rootLayers.getSubLayers();
             self.__collect(loop, 0, yamlCache, update, verbose)

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -130,7 +130,7 @@ class Layer:
 
             canSwitch = self.__scm.canSwitch(getScm(oldState["prop"]))
             if canSwitch:
-                log("SWITCH: Layer '{}' .. ok".format(self.getName()), EXECUTED, INFO)
+                log("SWITCH: Layer '{}' .. ok".format(self.getName()), EXECUTED, NORMAL)
                 ret = await invoker.executeScmSwitch(self.__scm, oldState["prop"])
                 if ret == 0:
                     BobState().setLayerState(self.__layerDir, newState)

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -27,7 +27,7 @@ class LayersConfig:
         ret.__policies = self.__policies
 
         ret.__whiteList.update([c.upper() if self.__platform == "win32" else c
-            for c in config.get("layersWhiteList", []) ])
+            for c in config.get("layersWhitelist", []) ])
         ret.__scmOverrides[0:0] = [ ScmOverride(o) for o in config.get("layersScmOverrides", []) ]
 
         if rootLayer:

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -104,7 +104,7 @@ class Layer:
                           trace = verbose >= DEBUG,
                           redirect=False, executor=None)
         newState = {}
-        newState["digest"] = self.__scm.asDigestScript(),
+        newState["digest"] = self.__scm.asDigestScript()
         newState["prop"] = {k:v for k,v in self.__scm.getProperties(False).items() if v is not None}
 
         oldState = BobState().getLayerState(self.__layerDir)

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -179,12 +179,14 @@ class Layer:
         configYaml = os.path.join(self.__layerDir, "config.yaml")
         for l in config.get('layers', []):
             scmSpec = l.getScm()
-            if scmSpec is None: continue
-            scmSpec.update({'recipe':configYaml})
-            layerScm = Scm(scmSpec,
-                           Env(self.__defines),
-                           overrides=self.__config.scmOverrides(),
-                           recipeSet=self.__config)
+            if scmSpec is None:
+                layerScm = None
+            else:
+                scmSpec.update({'recipe':configYaml})
+                layerScm = Scm(scmSpec,
+                               Env(self.__defines),
+                               overrides=self.__config.scmOverrides(),
+                               recipeSet=self.__config)
             self.__subLayers.append(Layer(l.getName(),
                                           self.__config,
                                           self.__defines,

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -27,7 +27,7 @@ class LayersConfig:
 
         ret.__whiteList.update([c.upper() if self.__platform == "win32" else c
             for c in config.get("layersWhiteList", []) ])
-        ret.__scmOverrides.extend([ ScmOverride(o) for o in config.get("layersScmOverrides", []) ])
+        ret.__scmOverrides[0:0] = [ ScmOverride(o) for o in config.get("layersScmOverrides", []) ]
 
         if rootLayer:
             ret.__policies = RecipeSet.calculatePolicies(config)
@@ -254,7 +254,7 @@ class Layers:
         configSchema = (schema.Schema(RecipeSet.STATIC_CONFIG_LAYER_SPEC), b'')
         config = LayersConfig()
         with YamlCache() as yamlCache:
-            for c in self.__layerConfigFiles:
+            for c in reversed(self.__layerConfigFiles):
                 c += ".yaml"
                 if not os.path.exists(c):
                     raise BuildError(f"Layer config file {c} not found" )

--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -321,6 +321,28 @@ def getPlatformTag():
     __platformTag = ret
     return ret
 
+def getPlatformEnvWhiteList(platform):
+    """Return default environment whitelist, depending on the platform"""
+
+    ret = set()
+    if platform == 'win32':
+        ret |= set(["ALLUSERSPROFILE", "APPDATA",
+            "COMMONPROGRAMFILES", "COMMONPROGRAMFILES(X86)", "COMSPEC",
+            "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
+            "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)", "SYSTEMDRIVE",
+            "SYSTEMROOT", "TEMP", "TMP", "WINDIR"])
+    else:
+        ret |= set(["PATH", "TERM", "SHELL", "USER", "HOME"])
+
+    if platform in ('cygwin', 'msys'):
+        ret |= set(["ALLUSERSPROFILE", "APPDATA",
+            "COMMONPROGRAMFILES", "CommonProgramFiles(x86)", "COMSPEC",
+            "HOMEDRIVE", "HOMEPATH", "LOCALAPPDATA", "PATH", "PATHEXT",
+            "ProgramData", "PROGRAMFILES", "ProgramFiles(x86)", "SYSTEMDRIVE",
+            "SYSTEMROOT", "TEMP", "TMP", "WINDIR"])
+
+    return ret
+
 __bashPath = None
 
 def getBashPath():

--- a/test/black-box/layers-checkout/__layers/bar/2/recipes/bar.yaml
+++ b/test/black-box/layers-checkout/__layers/bar/2/recipes/bar.yaml
@@ -1,3 +1,0 @@
-packageScript: "/bin/true"
-provideVars:
-  BAR_VERSION: "2"

--- a/test/black-box/layers-checkout/__layers/baz/1/recipes/baz.yaml
+++ b/test/black-box/layers-checkout/__layers/baz/1/recipes/baz.yaml
@@ -1,3 +1,0 @@
-packageScript: "/bin/true"
-provideVars:
-  BAZ_VERSION: "1"

--- a/test/black-box/layers-checkout/__layers/baz/2/recipes/baz.yaml
+++ b/test/black-box/layers-checkout/__layers/baz/2/recipes/baz.yaml
@@ -1,3 +1,0 @@
-packageScript: "/bin/true"
-provideVars:
-  BAZ_VERSION: "2"

--- a/test/black-box/layers-checkout/__layers/foo/config.yaml
+++ b/test/black-box/layers-checkout/__layers/foo/config.yaml
@@ -1,9 +1,0 @@
-layers:
-  - bar:
-      checkoutSCM:
-        scm: import
-        url: "__layers/bar/2"
-  - baz:
-      checkoutSCM:
-        scm: import
-        url: "__layers/baz/1"

--- a/test/black-box/layers-checkout/__layers/foo/recipes/foo.yaml
+++ b/test/black-box/layers-checkout/__layers/foo/recipes/foo.yaml
@@ -1,2 +1,0 @@
-buildScript: "true"
-packageScript: "true"


### PR DESCRIPTION
This fixes a couple of subtle corner cases that so far got unnoticed:

 * We still parsed the system- and user-global default.yaml
   configuration files. The data from these files was not used except
   the URM SCM mirrors. Now everything depends just on the layer
   configuration files.
 * The layersScmOverrides and layersWhitelist keys were only
   appended when traversing the layers. This causes settings of
   unrelated layers to affect each other. Now the layer settings are
   handled strictly hierarchical.
 * It was possible to switch to the "import" SCM via layersScmOverrides.
   This is prevented now by always using the layers SCM schema.
 * There were no default environment white list entries. This was
   inconsistent to the regular white list handling.

Additionally, it improves the following things:

* Use relative paths for layers. This shortens all log messages.
* Show new/attic/overridden flags on "bob layers status"