### PR TITLE
Add additional sandbox modes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.svg binary
+doc/_static/d3.v4.min.js binary

--- a/contrib/bash-completion/bob
+++ b/contrib/bash-completion/bob
@@ -57,11 +57,8 @@ __bob_complete_path()
    # influence parsing and must be passed to "bob ls".
    for i in "${words[@]}"; do
       case "$i" in
-         --sandbox)
-            sandbox="--sandbox"
-            ;;
-         --no-sandbox)
-            sandbox="--no-sandbox"
+         --*sandbox)
+            sandbox="$i"
             ;;
 		 -c?* | -D?*)
 		    cmd_settings+=( "$i" )
@@ -130,7 +127,7 @@ __bob_cook()
    elif [[ "$prev" = "--always-checkout" ]] ; then
       COMPREPLY=( )
    else
-      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --clean-checkout --attic --no-attic"
+      __bob_complete_path "--destination -j --jobs -k --keep-going -f --force -n --no-deps -p --with-provided --without-provided -A --no-audit --audit -b --build-only -B --checkout-only --normal --clean --incremental --always-checkout --resume -q --quiet -v --verbose --no-logfiles -D -c -e -E -M --upload --link-deps --no-link-deps --download --download-layer --shared --no-shared --install --no-install --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox --clean-checkout --attic --no-attic"
    fi
 }
 
@@ -151,7 +148,7 @@ __bob_graph()
    if [[ "$prev" = "-t" || "$prev" = "--type" ]] ; then
          __bob_complete_words "d3 dot"
    else
-      __bob_complete_path "-c -D -e --exclude -f --filename -H --highlight -n --max-depth -t --type -o --sandbox --no-sandbox"
+      __bob_complete_path "-c -D -e --exclude -f --filename -H --highlight -n --max-depth -t --type -o --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox"
    fi
 }
 
@@ -162,7 +159,7 @@ __bob_help()
 
 __bob_ls()
 {
-   __bob_complete_path "-a --all -c -D -d --direct --no-sandbox -o --origin -p --prefixed -r --recursive --sandbox -u --unsorted"
+   __bob_complete_path "-a --all -c -D -d --direct --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox -o --origin -p --prefixed -r --recursive --sandbox -u --unsorted"
 }
 
 __bob_init()
@@ -183,7 +180,7 @@ __bob_jenkins_add()
 
    case "$cur" in
       -*)
-         __bob_complete_words "--clean --credentials --download --help --host-platform --keep --longdescription --no-sandbox --nodes --prefix --root --shortdescription --upload --windows -D -h -n -o -p -r -w"
+         __bob_complete_words "--clean --credentials --download --help --host-platform --keep --longdescription --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox --nodes --prefix --root --shortdescription --upload --windows -D -h -n -o -p -r -w"
          ;;
       *)
          case "$prev" in
@@ -304,7 +301,7 @@ __bob_jenkins_set_options()
 
    case "$cur" in
       -*)
-         __bob_complete_words "-h --help --reset -n --nodes -o -p --prefix --add-root --del-root -D -U --credentials --authtoken --shortdescription --longdescription --keep --no-keep --download --no-download --upload --no-upload --sandbox --no-sandbox --clean --incremental --host-platform"
+         __bob_complete_words "-h --help --reset -n --nodes -o -p --prefix --add-root --del-root -D -U --credentials --authtoken --shortdescription --longdescription --keep --no-keep --download --no-download --upload --no-upload --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox --clean --incremental --host-platform"
          ;;
       *)
          case "$prev" in
@@ -353,7 +350,7 @@ __bob_project()
    elif [[ -z "$command" ]] ; then
       case "$cur" in
          -*)
-            __bob_complete_words "-b -c -D --download -E -e -j --list -n --no-sandbox --resume --sandbox"
+            __bob_complete_words "-b -c -D --download -E -e -j --list -n --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox --resume --sandbox"
             ;;
          *)
             __bob_complete_words "$($bob --color=never project --list 2>/dev/null)"
@@ -366,22 +363,22 @@ __bob_project()
 
 __bob_query_scm()
 {
-    __bob_complete_path "-c -D -f --default -r --recursive --sandbox --no-sandbox"
+    __bob_complete_path "-c -D -f --default -r --recursive --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox"
 }
 
 __bob_query_path()
 {
-  __bob_complete_path "-f -D -c --sandbox --no-sandbox --develop --release"
+  __bob_complete_path "-f -D -c --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox --develop --release"
 }
 
 __bob_query_meta()
 {
-  __bob_complete_path " -c -D -r --recursive --sandbox --no-sandbox"
+  __bob_complete_path " -c -D -r --recursive --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox"
 }
 
 __bob_query_recipe()
 {
-    __bob_complete_path "-c -D --sandbox --no-sandbox"
+    __bob_complete_path "-c -D --sandbox --no-sandbox --slim-sandbox --dev-sandbox --strict-sandbox"
 }
 
 __bob_status()
@@ -419,7 +416,8 @@ __bob_show()
     elif [[ "$prev" = "--indent" ]] ; then
         COMPREPLY=( )
     else
-        __bob_complete_path "-D -c --sandbox --no-sandbox --show-empty
+        __bob_complete_path "-D -c --sandbox --no-sandbox --slim-sandbox
+            --dev-sandbox --strict-sandbox --show-empty
             --show-common --indent --no-indent --format -f"
     fi
 }

--- a/doc/manpages/bob-build.rst
+++ b/doc/manpages/bob-build.rst
@@ -22,7 +22,8 @@ Synopsis
               [-lc LAYERCONFIG] [-e NAME] [-E] [-M META] [--upload]
               [--link-deps] [--no-link-deps] [--download MODE]
               [--download-layer MODE] [--shared | --no-shared]
-              [--install | --no-install] [--sandbox | --no-sandbox]
+              [--install | --no-install]
+              [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
               [--clean-checkout] [--attic | --no-attic]
               PACKAGE [PACKAGE ...]
 

--- a/doc/manpages/bob-dev.rst
+++ b/doc/manpages/bob-dev.rst
@@ -22,10 +22,10 @@ Synopsis
             [-lc LAYERCONFIG] [-e NAME] [-E] [-M META] [--upload]
             [--link-deps] [--no-link-deps] [--download MODE]
             [--download-layer MODE] [--shared | --no-shared]
-            [--install | --no-install] [--sandbox | --no-sandbox]
+            [--install | --no-install]
+            [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
             [--clean-checkout] [--attic | --no-attic]
             PACKAGE [PACKAGE ...]
-
 
 Description
 -----------

--- a/doc/manpages/bob-graph.rst
+++ b/doc/manpages/bob-graph.rst
@@ -15,7 +15,8 @@ Synopsis
 
 ::
 
-    bob graph [-h] [-D DEFINES] [-c CONFIGFILE] [--sandbox | --no-sandbox]
+    bob graph [-h] [-D DEFINES] [-c CONFIGFILE]
+              [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
               [--destination DEST] [-e EXCLUDES] [-f FILENAME]
               [-H HIGHLIGHTS] [-n MAX_DEPTH] [-t {d3,dot}] [-o OPTIONS]
               PACKAGE [PACKAGE ...]
@@ -45,6 +46,9 @@ Options
 ``--destination``
     Destination of graph output files.
 
+``--dev-sandbox``
+    Enable development sandboxing. Include sandbox dependencies in the graph.
+
 ``-e, --excludes``
     Do not show packages matching this regex. (And all it's
     dependencies)
@@ -64,7 +68,13 @@ Options
     the default.
 
 ``--sandbox``
-    Enable sandboxing. Include sandbox dependencies in the graph.
+    Enable partial sandboxing. Include sandbox dependencies in the graph.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing. Include sandbox dependencies in the graph.
 
 ``-t, --type``
     Set the graph type. ``d3`` (default) or ``dot``.

--- a/doc/manpages/bob-jenkins.rst
+++ b/doc/manpages/bob-jenkins.rst
@@ -26,8 +26,8 @@ Available sub-commands:
     bob jenkins add [-h] [-n NODES] [-o OPTIONS]
                     [--host-platform {linux,msys,win32}] [-w] [-p PREFIX]
                     [-r ROOT] [-D DEFINES] [--keep] [--download] [--upload]
-                    [--no-sandbox] [--credentials CREDENTIALS]
-                    [--clean | --incremental]
+                    [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
+                    [--credentials CREDENTIALS] [--clean | --incremental]
                     [--shortdescription | --longdescription]
                     name url
     bob jenkins export [-h] name dir
@@ -50,7 +50,7 @@ Available sub-commands:
                             [--keep | --no-keep]
                             [--download | --no-download]
                             [--upload | --no-upload]
-                            [--sandbox | --no-sandbox]
+                            [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
                             [--clean | --incremental]
                             name
     bob jenkins set-url [-h] name url
@@ -125,6 +125,13 @@ Options
 
 ``--del-root DEL_ROOT``
     Remove existing root package.
+
+``--dev-sandbox``
+    Enable development sandboxing.
+
+    Always build packages in an isolated environment where only declared
+    dependencies are visible. If a sandbox image is available, it is used.
+    Otherwise the host paths are made read-only.
 
 ``--download``
     Enable downloads from binary archive. Disabled by default. There must
@@ -224,7 +231,8 @@ Options
     Disable sandboxing during builds.
 
     Unless required by the project, it is discouraged to disable the sandbox
-    feature. See ``--sandbox`` for the opposite switch.
+    feature. See ``--sandbox``, ``--slim-sandbox``, ``--dev-sandbox`` or
+    ``--strict-sandbox`` for the opposite switches.
 
 ``--no-ssl-verify``
     Disable HTTPS certificate checking.
@@ -296,7 +304,11 @@ Options
     on the previous state.
 
 ``--sandbox``
-    Enable sandboxing. This is the default.
+    Enable partial sandboxing. This is the default.
+
+    Build packages in an ephemeral container if a sandbox image is available
+    for the package. Inside the sandbox, stable execution paths are used. In
+    absence of a sandbox image, no isolation is performed.
 
 ``--shortdescription``
     Do not calculate every possible path of each package in a job for the
@@ -304,6 +316,22 @@ Options
     project complexity, might reduce the configuration time considerably. The
     drawback is that not all packages are then listed in the job description.
     For each unique package only one example path will be shown.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+    Build packages in an isolated mount namespace. Most of the host paths
+    are available read-only. Other workspaces are hidden when building a
+    package unless they are a declared dependency. An optionally available
+    sandbox image is *not* used.
+
+``--strict-sandbox``
+    Enable strict sandboxing.
+
+    Always build packages in an isolated environment where only declared
+    dependencies are visible. If a sandbox image is available, it is used.
+    Otherwise the host paths are made read-only. The build path is always
+    a reproducible, stable path.
 
 ``-U UNDEFINES``
     Undefine environment variable override. This removes a variable previously

--- a/doc/manpages/bob-ls.rst
+++ b/doc/manpages/bob-ls.rst
@@ -16,9 +16,9 @@ Synopsis
 ::
 
     bob ls [-h] [-a] [-A] [-o] [-r] [-u] [-p | -d] [-D DEFINES]
-           [-c CONFIGFILE] [--sandbox | --no-sandbox]
+           [-c CONFIGFILE]
+           [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
            [package]
-
 
 Description
 -----------
@@ -80,6 +80,9 @@ Options
 ``-D DEFINES``
     Override default environment variable
 
+``--dev-sandbox``
+    Enable development sandboxing.
+
 ``--no-sandbox``
     Disable sandboxing
 
@@ -95,7 +98,13 @@ Options
     Recursively display dependencies
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.
 
 ``-u, --unsorted``
     Show the packages in the order they were named in the recipe. By default

--- a/doc/manpages/bob-project.rst
+++ b/doc/manpages/bob-project.rst
@@ -17,7 +17,7 @@ Synopsis
 
     bob project [-h] [--list] [-D DEFINES] [-c CONFIGFILE] [-e NAME] [-E]
                 [--download MODE] [--resume] [-n] [-b] [-j [JOBS]]
-                [--sandbox | --no-sandbox]
+                [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
                 [projectGenerator] [package] ...
 
 
@@ -31,6 +31,13 @@ Options
 
 ``-c CONFIGFILE``
     Use config File
+
+``--dev-sandbox``
+    Enable development sandboxing.
+
+    Always build packages in an isolated environment where only declared
+    dependencies are visible. If a sandbox image is available, it is used.
+    Otherwise the host paths are made read-only.
 
 ``--download MODE``
     Download from binary archive (yes, no, deps, packages)
@@ -57,7 +64,7 @@ Options
     work
 
 ``--no-sandbox``
-    Disable sandboxing
+    Disable sandboxing. This is the default.
 
 ``-b``
     Do build only (bob dev -b) before generate project Files. No checkout
@@ -66,7 +73,27 @@ Options
     Resume build where it was previously interrupted
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
+
+    Build packages in an ephemeral container if a sandbox image is available
+    for the package. Inside the sandbox, stable execution paths are used. In
+    absence of a sandbox image, no isolation is performed.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+    Build packages in an isolated mount namespace. Most of the host paths
+    are available read-only. Other workspaces are hidden when building a
+    package unless they are a declared dependency. An optionally available
+    sandbox image is *not* used.
+
+``--strict-sandbox``
+    Enable strict sandboxing.
+
+    Always build packages in an isolated environment where only declared
+    dependencies are visible. If a sandbox image is available, it is used.
+    Otherwise the host paths are made read-only. The build path is always
+    a reproducible, stable path.
 
 Eclipse CDT project generator
 -----------------------------

--- a/doc/manpages/bob-query-meta.rst
+++ b/doc/manpages/bob-query-meta.rst
@@ -17,7 +17,7 @@ Synopsis
 ::
 
     bob query-meta [-h] [-D DEFINES] [-c CONFIGFILE] [-r]
-                   [--sandbox | --no-sandbox]
+                   [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
                    packages [packages ...]
 
 Description
@@ -34,6 +34,9 @@ Options
 ``-D DEFINES``
     Override default environment variable
 
+``--dev-sandbox``
+    Enable development sandboxing.
+
 ``--no-sandbox``
     Disable sandboxing
 
@@ -41,4 +44,10 @@ Options
     Also list metaEnvironment variables for all dependencies.
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.

--- a/doc/manpages/bob-query-path.rst
+++ b/doc/manpages/bob-query-path.rst
@@ -15,9 +15,11 @@ Synopsis
 
 ::
 
-    bob query-path [-h] [-f FORMAT] [-D DEFINES] [-c CONFIGFILE]
-                   [--sandbox | --no-sandbox] [--develop | --release]
-                   [-q] [--fail] PACKAGE [PACKAGE ...]
+    bob query-path [-h] [-f FORMAT] [-D DEFINES] [-c CONFIGFILE] [-q]
+                   [--fail]
+                   [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
+                   [--develop | --release]
+                   PACKAGE [PACKAGE ...]
 
 Description
 -----------
@@ -26,15 +28,15 @@ This command lists existing workspace directory names for packages given
 on the command line. Output is formatted with a format string that can
 contain placeholders
 
-    +----------+------------------+
-    |{name}    |package name      |
-    +----------+------------------+
-    |{src}     |checkout directory|
-    +----------+------------------+
-    |{build}   |build directory   |
-    +----------+------------------+
-    |{dist}    |package directory |
-    +----------+------------------+
+    +-----------+--------------------+
+    | {name}    | package name       |
+    +-----------+--------------------+
+    | {src}     | checkout directory |
+    +-----------+--------------------+
+    | {build}   | build directory    |
+    +-----------+--------------------+
+    | {dist}    | package directory  |
+    +-----------+--------------------+
 
 The default format is '{name}<tab>{dist}'.
 
@@ -51,6 +53,9 @@ Options
 
 ``-D DEFINES``
     Override default environment variable
+
+``--dev-sandbox``
+    Enable development sandboxing.
 
 ``--develop``
     Use developer mode
@@ -71,5 +76,10 @@ Options
     Use release mode
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
 
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.

--- a/doc/manpages/bob-query-recipe.rst
+++ b/doc/manpages/bob-query-recipe.rst
@@ -16,7 +16,7 @@ Synopsis
 ::
 
     bob query-recipe [-h] [-D DEFINES] [-c CONFIGFILE]
-                     [--sandbox | --no-sandbox]
+                     [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
                      package
 
 Description
@@ -33,8 +33,17 @@ Options
 ``-D DEFINES``
     Override default environment variable
 
+``--dev-sandbox``
+    Enable development sandboxing.
+
 ``--no-sandbox``
     Disable sandboxing
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.

--- a/doc/manpages/bob-query-scm.rst
+++ b/doc/manpages/bob-query-scm.rst
@@ -14,8 +14,10 @@ Synopsis
 --------
 
 ::
+
     bob query-scm [-h] [-D DEFINES] [-c CONFIGFILE] [-f FORMATS]
-                  [--default DEFAULT] [-r] [--sandbox | --no-sandbox]
+                  [--default DEFAULT] [-r]
+                  [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
                   packages [packages ...]
 
 Description
@@ -44,6 +46,9 @@ Options
 ``--default DEFAULT``
     Default for missing attributes (default: "")
 
+``--dev-sandbox``
+    Enable development sandboxing.
+
 ``-f FORMATS``
     Output format for scm (syntax: scm=format). Can be specified multiple times.
 
@@ -54,4 +59,10 @@ Options
     Recursively display dependencies
 
 ``--sandbox``
-    Enable sandboxing
+    Enable partial sandboxing.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.

--- a/doc/manpages/bob-show.rst
+++ b/doc/manpages/bob-show.rst
@@ -15,7 +15,8 @@ Synopsis
 
 ::
 
-    bob show [-h] [-D DEFINES] [-c CONFIGFILE] [--sandbox | --no-sandbox]
+    bob show [-h] [-D DEFINES] [-c CONFIGFILE]
+             [--sandbox | --slim-sandbox | --dev-sandbox | --strict-sandbox | --no-sandbox]
              [--show-empty] [--show-common] [--indent INDENT | --no-indent]
              [--format {yaml,json,flat,diff}]
              [-f {buildNetAccess,buildTools,buildToolsWeak,buildVars,buildVarsWeak,
@@ -62,6 +63,9 @@ the properties that are different between both packages.
 Options
 -------
 
+``--dev-sandbox``
+    Enable development sandboxing.
+
 ``-f FIELD``
    Show only the given ``FIELD``. This option may be specified more than once
    to show additional fields. If this option is not given then all fields are
@@ -83,7 +87,7 @@ Options
    Disable sandboxing.
 
 ``--sandbox``
-   Enable sandboxing.
+   Enable partial sandboxing.
 
 ``--show-common``
    The ``diff`` format suppresses identical fields by default. This option
@@ -94,3 +98,9 @@ Options
    as short as possible. Specifying this option will still show them. If the
    package does not have a checkout- or build-step the respective properties do
    not exist and will never be shown.
+
+``--slim-sandbox``
+    Enable slim sandboxing.
+
+``--strict-sandbox``
+    Enable strict sandboxing.

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -365,7 +365,7 @@ The following built in string functions are supported:
 * ``$(if-then-else,condition,then,else)``: The expansion of ``condition`` is
   interpreted as a boolean value. If the condition is true the expansion of
   ``then`` is returned. Otherwise ``else`` is returned.
-* ``$(is-sandbox-enabled)``: Return ``true`` if a sandbox is enabled in the
+* ``$(is-sandbox-enabled)``: Return ``true`` if a sandbox image is used in the
   current context, ``false`` otherwise.
 * ``$(is-tool-defined,name)``: If ``name`` is a defined tool in the current
   context the function will return ``true``. Otherwise ``false`` is returned.

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -2298,7 +2298,10 @@ jobs            ``-j``                 Integer
 link_deps       ``--[no-]link-deps``   Boolean
 no_deps         ``-n``                 Boolean
 no_logfiles     ``--no-logfiles``      Boolean
-sandbox         ``--[no-]sandbox``     Boolean
+sandbox         ``--[no-]sandbox`` |   Boolean / String (``yes``, ``no``, ``slim``,
+                ``--slim-sandbox`` |   ``dev``, ``strict``)
+                ``--dev-sandbox`` |
+                ``--strict-sandbox``
 shared          ``--[no-]shared``      Boolean
 upload          ``--upload``           Boolean
 verbosity       ``-q | -v``            Integer (-2[quiet] .. 3[verbose], default 0)

--- a/doc/manual/extending.rst
+++ b/doc/manual/extending.rst
@@ -162,7 +162,7 @@ passed:
 
 * ``env``: dict of all available environment variables at the current context
 * ``recipe``: the current :class:`bob.input.Recipe`
-* ``sandbox``: ``True`` if a sandbox is used. ``False`` if no sandbox was
+* ``sandbox``: ``True`` if a sandbox *image* is used. ``False`` if no sandbox image was
   configured or if it is disabled (e.g. ``--no-sandbox`` option was specified).
 
 In the future additional keyword args may be added without notice. Such string

--- a/doc/manual/extending.rst
+++ b/doc/manual/extending.rst
@@ -209,7 +209,9 @@ Currently the following additional kwargs are passed:
  * ``packageSteps``: list of all package steps (:class:`bob.input.Step`) used
    in the job
  * ``prefix``: Prefix of all job names
- * ``sandbox``: Boolean whether sandbox should be used
+ * ``sandbox``: Boolean whether sandbox should be used. Plugins starting with
+   API version ``0.25`` are passed the sandbox mode as string (``no``, ``yes``,
+   ``slim``, ``dev`` or ``strict``).
  * ``url``: URL of Jenkins instance
  * ``windows``: True if Jenkins runs on Windows
 

--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -407,6 +407,7 @@ cd {ROOT}
         self.__installSharedPackages = False
         self.__executor = None
         self.__attic = True
+        self.__slimSandbox = False
 
     def setExecutor(self, executor):
         self.__executor = executor
@@ -504,6 +505,9 @@ cd {ROOT}
 
     def setAtticEnable(self, enable):
         self.__attic = enable
+
+    def setSlimSandbox(self, enable):
+        self.__slimSandbox = enable
 
     def setShareHandler(self, handler):
         self.__share = handler
@@ -737,7 +741,8 @@ cd {ROOT}
         logFile = os.path.join(workspacePath, "..", "log.txt")
         scriptHint = os.path.join(workspacePath, "..", "script")
         spec = StepSpec.fromStep(step, envFile, self.__envWhiteList, logFile,
-            scriptHint=scriptHint, isJenkins=step.JENKINS)
+            scriptHint=scriptHint, isJenkins=step.JENKINS,
+            slimSandbox=self.__slimSandbox)
 
         # Write invocation wrapper except on Jenkins. There will be nobody
         # around to actually execute it...
@@ -1934,7 +1939,8 @@ cd {ROOT}
         return fingerprint
 
     async def __runFingerprintScript(self, step, logger):
-        spec = StepSpec.fromStep(step, None, self.__envWhiteList, isJenkins=step.JENKINS)
+        spec = StepSpec.fromStep(step, None, self.__envWhiteList, isJenkins=step.JENKINS,
+                                 slimSandbox=self.__slimSandbox)
         invoker = Invoker(spec, self.__preserveEnv, True,
                           self.__verbose >= INFO, self.__verbose >= NORMAL,
                           self.__verbose >= DEBUG, self.__bufferedStdIO,
@@ -1952,7 +1958,8 @@ cd {ROOT}
 
     async def __runScmSwitch(self, step, scmPath, scm, oldSpec):
         logFile = os.path.join(step.getWorkspacePath(), "..", "log.txt")
-        spec = StepSpec.fromStep(step, None, self.__envWhiteList, logFile, isJenkins=step.JENKINS)
+        spec = StepSpec.fromStep(step, None, self.__envWhiteList, logFile, isJenkins=step.JENKINS,
+                                 slimSandbox=self.__slimSandbox)
         invoker = Invoker(spec, self.__preserveEnv, self.__noLogFile,
             self.__verbose >= INFO, self.__verbose >= NORMAL,
             self.__verbose >= DEBUG, self.__bufferedStdIO,

--- a/pym/bob/cmds/build/query.py
+++ b/pym/bob/cmds/build/query.py
@@ -45,8 +45,16 @@ been executed or does not exist), the line is omitted.
         help="Return a non-zero error code in case of errors")
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--sandbox', action='store_true', help="Enable sandboxing")
-    group.add_argument('--no-sandbox', action='store_false', dest='sandbox', help="Disable sandboxing")
+    group.add_argument('--sandbox', action='store_true', default=False,
+        help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
+    group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
+        help="Disable sandboxing")
     parser.set_defaults(sandbox=None)
 
     group = parser.add_mutually_exclusive_group()

--- a/pym/bob/cmds/graph.py
+++ b/pym/bob/cmds/graph.py
@@ -513,6 +513,12 @@ def doGraph(argv, bobRoot):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
     parser.add_argument('--destination', metavar="DEST",

--- a/pym/bob/cmds/jenkins/exec.py
+++ b/pym/bob/cmds/jenkins/exec.py
@@ -30,6 +30,7 @@ class Spec:
         self.platform = None
         self.__recipesAudit = []
         self.__execIR = []
+        self.slimSandbox = False
 
         with open(specFile, "r") as f:
             f.readline() # skip shebang
@@ -65,6 +66,8 @@ class Spec:
             self.platform = v
         elif k == "always-checkout":
             self.scmAlwaysCheckout = isTrue(v)
+        elif k == "slimSandbox":
+            self.slimSandbox = isTrue(v)
         else:
             raise AssertionError(line)
 
@@ -237,6 +240,7 @@ def doJenkinsExecuteRun(argv, bobRoot):
             builder.setShareMode(True, True)
         if spec.scmAlwaysCheckout:
             builder.setAlwaysCheckout([".*"])
+        builder.setSlimSandbox(spec.slimSandbox)
         builder.cook(ir.getRoots(), False, loop)
 
     return 0

--- a/pym/bob/cmds/jenkins/jenkins.py
+++ b/pym/bob/cmds/jenkins/jenkins.py
@@ -1206,8 +1206,8 @@ def doJenkinsRm(recipes, argv):
     BobState().delJenkins(args.name)
 
 def applyHooks(hooks, job, info, reverse=False):
-    for h in (reversed(hooks) if reverse else hooks):
-        job = h(job, **info)
+    for hook, apiVersion in (reversed(hooks) if reverse else hooks):
+        job = hook(job, **info)
     return job
 
 def doJenkinsPush(recipes, argv):

--- a/pym/bob/cmds/jenkins/jenkins.py
+++ b/pym/bob/cmds/jenkins/jenkins.py
@@ -11,7 +11,7 @@ from ...languages import StepSpec
 from ...state import BobState, JenkinsConfig
 from ...tty import WarnOnce
 from ...utils import processDefines, runInEventLoop, sslNoVerifyContext, quoteCmdExe, \
-    getPlatformString
+    getPlatformString, SandboxMode, compareVersion
 from .intermediate import getJenkinsVariantId, PartialIR
 from pathlib import PurePosixPath
 from shlex import quote
@@ -443,6 +443,7 @@ class JenkinsJob:
             "copy=" + config.artifactsCopy,
             "share=" + config.sharedDir,
             "always-checkout=" + ("1" if config.scmAlwaysCheckout else "0"),
+            "slimSandbox=" + ("1" if config.sandbox.slimSandbox else "0"),
         ])
         if config.sharedQuota:
             execCmds.append("quota=" + config.sharedQuota)
@@ -742,7 +743,8 @@ def genJenkinsJobs(recipes, jenkins):
 
     packages = recipes.generatePackages(
         jenkinsNamePersister(jenkins, nameFormatter, config.uuid),
-        config.sandbox)
+        config.sandbox.sandboxEnabled,
+        config.sandbox.stablePaths)
     nameCalculator = JobNameCalculator(config.prefix)
     rootPackages = []
     for r in config.roots: rootPackages.extend(packages.queryPackagePath(r))
@@ -807,7 +809,16 @@ def doJenkinsAdd(recipes, argv):
         help="Download from binary archive")
     parser.add_argument('--upload', default=False, action='store_true',
         help="Upload to binary archive")
-    parser.add_argument('--no-sandbox', action='store_false', dest='sandbox', default=True,
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--sandbox', action='store_const', const="yes", default="yes",
+        help="Enable partial sandboxing")
+    group.add_argument('--slim-sandbox', action='store_const', const="slim", dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_const', const="dev", dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_const', const="strict", dest='sandbox',
+        help="Enable strict sandboxing")
+    group.add_argument('--no-sandbox', action='store_const', const="no", dest='sandbox',
         help="Disable sandboxing")
     parser.add_argument("--credentials", help="Credentials UUID for SCM checkouts")
     group = parser.add_mutually_exclusive_group()
@@ -836,7 +847,7 @@ def doJenkinsAdd(recipes, argv):
     config.defines = processDefines(args.defines)
     config.download = args.download
     config.upload = args.upload
-    config.sandbox = args.sandbox
+    config.sandbox = SandboxMode(args.sandbox)
     config.credentials = args.credentials
     config.clean = args.clean
     config.keep = args.keep
@@ -884,7 +895,7 @@ def doJenkinsExport(recipes, argv):
             'url' : config.url,
             'prefix' : config.prefix,
             'nodes' : config.nodes,
-            'sandbox' : config.sandbox,
+            'sandbox' : config.sandbox.mode,
             'windows' : config.windows,
             'hostPlatform' : config.hostPlatform,
             'checkoutSteps' : job.getCheckoutSteps(),
@@ -917,6 +928,14 @@ def doJenkinsLs(recipes, argv):
         help="Show additional information")
     args = parser.parse_args(argv)
 
+    SANDBOX_MODES = {
+        "no" : "disabled",
+        "yes" : "enabled, partial",
+        "slim" : "enabled, slim",
+        "dev" : "enabled, dev",
+        "strict" : "enabled, strict",
+    }
+
     for j in sorted(BobState().getAllJenkins()):
         print(j)
         cfg = BobState().getJenkinsConfig(j)
@@ -933,7 +952,7 @@ def doJenkinsLs(recipes, argv):
             print("    Download:", "enabled" if cfg.download else "disabled")
             print("    Upload:", "enabled" if cfg.upload else "disabled")
             print("    Clean builds:", "enabled" if cfg.clean else "disabled")
-            print("    Sandbox:", "enabled" if cfg.sandbox else "disabled")
+            print("    Sandbox:", SANDBOX_MODES[cfg.sandbox.mode])
             if cfg.credentials:
                 print("    Credentials:", cfg.credentials)
             options = cfg.getOptions()
@@ -1207,7 +1226,13 @@ def doJenkinsRm(recipes, argv):
 
 def applyHooks(hooks, job, info, reverse=False):
     for hook, apiVersion in (reversed(hooks) if reverse else hooks):
-        job = hook(job, **info)
+        if compareVersion(apiVersion, "0.24.1.dev106") < 0:
+            # Retain pre 0.25 compatibility of 'sandbox' info item
+            args = info.copy()
+            args['sandbox'] = args['sandbox'] != "no"
+        else:
+            args = info
+        job = hook(job, **args)
     return job
 
 def doJenkinsPush(recipes, argv):
@@ -1288,7 +1313,7 @@ def doJenkinsPush(recipes, argv):
                 'url' : config.url,
                 'prefix' : config.prefix,
                 'nodes' : config.nodes,
-                'sandbox' : config.sandbox,
+                'sandbox' : config.sandbox.mode,
                 'windows' : config.windows,
                 'hostPlatform' : config.hostPlatform,
                 'checkoutSteps' : job.getCheckoutSteps(),
@@ -1501,9 +1526,15 @@ def doJenkinsSetOptions(recipes, argv):
     group.add_argument('--no-upload', action='store_false', dest='upload',
         help="Disable binary archive upload")
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--sandbox', action='store_true', default=None,
-        help="Enable sandboxing")
-    group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
+    group.add_argument('--sandbox', action='store_const', const="yes", default=None,
+        help="Enable partial sandboxing")
+    group.add_argument('--slim-sandbox', action='store_const', const="slim", dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_const', const="dev", dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_const', const="strict", dest='sandbox',
+        help="Enable strict sandboxing")
+    group.add_argument('--no-sandbox', action='store_const', const="no", dest='sandbox',
         help="Disable sandboxing")
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--clean', action='store_true', default=None,
@@ -1543,7 +1574,7 @@ def doJenkinsSetOptions(recipes, argv):
     if args.upload is not None:
         config.upload = args.upload
     if args.sandbox is not None:
-        config.sandbox = args.sandbox
+        config.sandbox = SandboxMode(args.sandbox)
     if defines:
         config.defines.update(defines)
     for d in args.undefines:

--- a/pym/bob/cmds/misc.py
+++ b/pym/bob/cmds/misc.py
@@ -90,6 +90,12 @@ def doLS(argv, bobRoot):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
     args = parser.parse_args(argv)
@@ -138,6 +144,12 @@ def doQueryMeta(argv, bobRoot):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
     args = parser.parse_args(argv)
@@ -196,6 +208,12 @@ are used:
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
 
@@ -258,6 +276,12 @@ def doQueryRecipe(argv, bobRoot):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
 

--- a/pym/bob/cmds/show.py
+++ b/pym/bob/cmds/show.py
@@ -252,6 +252,12 @@ def doShow(argv, bobRoot):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--sandbox', action='store_true', default=False,
         help="Enable sandboxing")
+    group.add_argument('--slim-sandbox', action='store_false', dest='sandbox',
+        help="Enable slim sandboxing")
+    group.add_argument('--dev-sandbox', action='store_true', dest='sandbox',
+        help="Enable development sandboxing")
+    group.add_argument('--strict-sandbox', action='store_true', dest='sandbox',
+        help="Enable strict sandboxing")
     group.add_argument('--no-sandbox', action='store_false', dest='sandbox',
         help="Disable sandboxing")
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -3265,7 +3265,7 @@ class RecipeSet:
                 raise ParseError("Plugin '"+fileName+"': hook name must be a string!")
             if not callable(fun):
                 raise ParseError("Plugin '"+fileName+"': "+hook+": hook must be callable!")
-            self.__hooks.setdefault(hook, []).append(fun)
+            self.__hooks.setdefault(hook, []).append((fun, apiVersion))
 
         projectGenerators = manifest.get('projectGenerators', {})
         if not isinstance(projectGenerators, dict):
@@ -3344,7 +3344,7 @@ class RecipeSet:
         return mod
 
     def defineHook(self, name, value):
-        self.__hooks[name] = [value]
+        self.__hooks[name] = [(value, BOB_VERSION)]
 
     def setConfigFiles(self, configFiles):
         self.__configFiles = configFiles
@@ -3353,9 +3353,11 @@ class RecipeSet:
         return self.__commandConfig
 
     def getHook(self, name):
-        return self.__hooks[name][-1]
+        # just return the hook function
+        return self.__hooks[name][-1][0]
 
     def getHookStack(self, name):
+        # return list of hook functions with API version
         return self.__hooks.get(name, [])
 
     def getProjectGenerators(self):

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2940,7 +2940,7 @@ class RecipeSet:
             schema.Optional('link_deps') : bool,
             schema.Optional('no_deps') : bool,
             schema.Optional('no_logfiles') : bool,
-            schema.Optional('sandbox') : bool,
+            schema.Optional('sandbox') : schema.Or(bool, "no", "slim", "dev", "yes", "strict"),
             schema.Optional('shared') : bool,
             schema.Optional('upload') : bool,
             schema.Optional('verbosity') : int,

--- a/pym/bob/intermediate.py
+++ b/pym/bob/intermediate.py
@@ -64,6 +64,7 @@ class StepIR(AbstractIR):
         self.__data['isRelocatable'] = step.isRelocatable()
         self.__data['isShared'] = step.isShared()
         self.__data['sandbox'] = graph.addSandbox(step.getSandbox())
+        self.__data['stablePaths'] = step.stablePaths()
 
         if not partial:
             self.__data['isFingerprinted'] = step._isFingerprinted()
@@ -144,6 +145,9 @@ class StepIR(AbstractIR):
     def getWorkspacePath(self):
         return self.__data['workspacePath']
 
+    def stablePaths(self):
+        return self.__data['stablePaths']
+
     def getExecPath(self, referrer=None):
         """Return the execution path of the step.
 
@@ -153,10 +157,14 @@ class StepIR(AbstractIR):
         to this step while building.
         """
         if self.isValid():
-            if (referrer or self).getSandbox() is None:
-                return self.getStoragePath()
-            else:
+            stablePaths = self.stablePaths()
+            if stablePaths is None:
+                stablePaths = (referrer or self).getSandbox() is not None
+
+            if stablePaths:
                 return os.path.join("/bob", asHexStr(self.getVariantId()), "workspace")
+            else:
+                return self.getStoragePath()
         else:
             return "/invalid/exec/path/of/{}".format(self.getPackage().getName())
 

--- a/pym/bob/state.py
+++ b/pym/bob/state.py
@@ -6,7 +6,7 @@
 from .errors import ParseError
 from .stringparser import isTrue
 from .tty import colorize, WarnOnce, WARNING
-from .utils import replacePath, getPlatformString
+from .utils import replacePath, getPlatformString, SandboxMode
 import copy
 import errno
 import os
@@ -52,7 +52,7 @@ class JenkinsConfig:
         self.defines = config.get("defines", {}).copy()
         self.download = config.get("download", False)
         self.upload = config.get("upload", False)
-        self.sandbox = config.get("sandbox", True)
+        self.__sandbox = SandboxMode(config.get("sandbox", True))
         self.credentials = config.get("credentials", None)
         self.clean = config.get("clean", True)
         self.keep = config.get("keep", False)
@@ -83,7 +83,7 @@ class JenkinsConfig:
                 "options" : self.__options,
                 "prefix" : self.prefix,
                 "roots" : self.roots,
-                "sandbox" : self.sandbox,
+                "sandbox" : self.__sandbox.compatMode,
                 "shortdescription" : self.shortdescription,
                 "upload" : self.upload,
                 "url" : self.__url,
@@ -97,7 +97,7 @@ class JenkinsConfig:
         self.defines = {}
         self.download = False
         self.upload = False
-        self.sandbox = True
+        self.__sandbox = SandboxMode(True)
         self.credentials = None
         self.clean = True
         self.keep = False
@@ -105,6 +105,17 @@ class JenkinsConfig:
         self.shortdescription = False
         self.hostPlatform = getPlatformString()
         self.__options = {}
+
+    @property
+    def sandbox(self):
+        return self.__sandbox
+
+    @sandbox.setter
+    def sandbox(self, mode):
+        if isinstance(mode, SandboxMode):
+            self.__sandbox = mode
+        else:
+            self.__sandbox = SandboxMode(mode)
 
     @property
     def url(self):

--- a/pym/bob/utils.py
+++ b/pym/bob/utils.py
@@ -97,6 +97,34 @@ def removeUserFromUrl(url):
     # Nothing matched
     return url
 
+class SandboxMode:
+    def __init__(self, mode):
+        # normalize legacy boolean argument
+        if isinstance(mode, bool):
+            mode = "yes" if mode else "no"
+        assert mode in ("no", "yes", "slim", "dev", "strict")
+
+        self.mode = mode
+        self.sandboxEnabled = mode in ("dev", "yes", "strict")
+        self.slimSandbox = mode in ("slim", "dev", "strict")
+
+        if mode == "dev":
+            self.stablePaths = False
+        elif mode == "strict":
+            self.stablePaths = True
+        else:
+            self.stablePaths = None
+
+    @property
+    def compatMode(self):
+        # pre 0.25 compatibility
+        if self.mode == "no":
+            return False
+        elif self.mode == "yes":
+            return True
+        else:
+            return self.mode
+
 def removePath(path):
     if sys.platform == "win32":
         def onerror(func, path, exc):

--- a/test/black-box/jenkins-misc/config.yaml
+++ b/test/black-box/jenkins-misc/config.yaml
@@ -1,1 +1,3 @@
 bobMinimumVersion: "0.20"
+plugins:
+    - jenkins

--- a/test/black-box/jenkins-misc/plugins/jenkins.py
+++ b/test/black-box/jenkins-misc/plugins/jenkins.py
@@ -1,0 +1,17 @@
+from xml.etree import ElementTree
+
+def munge(config, checkoutSteps, buildSteps, packageSteps, **kwargs):
+    root = ElementTree.fromstring(config)
+    if root.find("./properties/test.bob.canary") is None:
+        ElementTree.SubElement(
+            root.find("properties"),
+            "test.bob.canary")
+    return ElementTree.tostring(root, encoding="UTF-8")
+
+manifest = {
+    'apiVersion' : "0.20",
+    'hooks' : {
+        'jenkinsJobCreate' : munge,
+        'jenkinsJobPostUpdate' : munge
+    }
+}

--- a/test/black-box/jenkins-misc/run.sh
+++ b/test/black-box/jenkins-misc/run.sh
@@ -13,6 +13,10 @@ expect_fail run_bob jenkins add local http://another.test/
 
 run_bob jenkins graph local
 
+# Plugins smoke test
+run_bob jenkins export local "$exp"
+grep -q "test.bob.canary" "$exp/root.xml"
+
 run_bob jenkins ls
 run_bob jenkins ls -v
 run_bob jenkins ls -vv

--- a/test/black-box/query-path/run.sh
+++ b/test/black-box/query-path/run.sh
@@ -52,20 +52,20 @@ test -n "$(run_bob query-path --release root/interm2/child)"
 #
 
 # Must report no path for all usages because we have not built.
-test -z "$(run_bob query-path --dev root)"
-test -z "$(run_bob query-path --dev root/interm1/child)"
-test -z "$(run_bob query-path --dev root/interm2/child)"
+test -z "$(run_bob query-path --develop root)"
+test -z "$(run_bob query-path --develop root/interm1/child)"
+test -z "$(run_bob query-path --develop root/interm2/child)"
 
 # Build everything
 run_bob dev root
 # Convert reported paths to unix format.
-set -- $(run_bob query-path --dev root | sed -e 's|\\|/|g')
+set -- $(run_bob query-path --develop root | sed -e 's|\\|/|g')
 test "$1" = "root"
 test "$2" = "dev/dist/root/1/workspace"
 
-# 'query-path --dev' is the default
+# 'query-path --develop' is the default
 PACKAGES="root root/interm1/child root/interm2/child"
-RESULT=$(run_bob query-path --dev $PACKAGES)
+RESULT=$(run_bob query-path --develop $PACKAGES)
 test "$RESULT" = "$(run_bob query-path $PACKAGES)"
 
 # No matter in which order we build, we must get the same result.
@@ -73,7 +73,7 @@ for i in $PACKAGES; do
     rm -rf work dev .bob-*
     run_bob dev $i
     run_bob dev root
-    test "$(run_bob query-path --dev $PACKAGES)" = "$RESULT"
+    test "$(run_bob query-path --develop $PACKAGES)" = "$RESULT"
 done
 
 

--- a/test/black-box/sandbox/config.yaml
+++ b/test/black-box/sandbox/config.yaml
@@ -1,0 +1,1 @@
+bobMinimumVersion: "0.24"

--- a/test/black-box/sandbox/recipes/isolation.yaml
+++ b/test/black-box/sandbox/recipes/isolation.yaml
@@ -1,0 +1,11 @@
+root: True
+
+depends:
+    - test-outside
+    - name: sandbox
+      use: [sandbox]
+      forward: True
+    - test-inside
+
+buildScript: "true"
+packageScript: "true"

--- a/test/black-box/sandbox/recipes/sandbox.yaml
+++ b/test/black-box/sandbox/recipes/sandbox.yaml
@@ -1,4 +1,7 @@
 # Empty sandbox that mounts the whole host
+packageScript: |
+    echo "canary" > canary.txt
+
 provideSandbox:
     paths: ["/usr/local/bin", "/usr/local/sbin", "/usr/bin", "/usr/sbin",
             "/bin", "/sbin"]

--- a/test/black-box/sandbox/recipes/test.yaml
+++ b/test/black-box/sandbox/recipes/test.yaml
@@ -1,0 +1,61 @@
+packageVars: [CANARY]
+packageScript: |
+    verifyIsolated()
+    {
+        if [[ $1 -ne 0 ]] ; then
+            if [[ -e "$CANARY" ]] ; then
+                echo "$CANARY exists in isolated environment" >&2
+                exit 1
+            fi
+        else
+            if [[ ! -e "$CANARY" ]] ; then
+                echo "$CANARY does not exists in host environment" >&2
+                exit 1
+            fi
+        fi
+    }
+
+    verifyImageUsed()
+    {
+        if [[ $1 -ne 0 ]] ; then
+            if [[ ! -e /canary.txt ]] ; then
+                echo "Sandbox image not used?" >&2
+                exit 1
+            fi
+        else
+            if [[ -e /canary.txt ]] ; then
+                echo "Canary found in host environment" >&2
+                exit 1
+            fi
+        fi
+    }
+
+    verifyStablePath()
+    {
+        if [[ $1 -ne 0 ]] ; then
+            if [[ $PWD != /bob/* ]] ; then
+                echo "No stable path inside sandbox" >&2
+                exit 1
+            fi
+        else
+            if [[ $PWD == /bob/* ]] ; then
+                echo "Stable path used in host environment" >&2
+                exit 1
+            fi
+        fi
+    }
+
+multiPackage:
+    outside:
+        packageVars: [OUTSIDE_ISOLATED, OUTSIDE_STABLE_PATH]
+        packageScript: |
+            verifyIsolated $OUTSIDE_ISOLATED
+            verifyImageUsed 0
+            verifyStablePath $OUTSIDE_STABLE_PATH
+
+    inside:
+        packageVars: [INSIDE_ISOLATED, INSIDE_IMAGE_USED, INSIDE_STABLE_PATH]
+        packageScript: |
+            verifyIsolated $INSIDE_ISOLATED
+            verifyImageUsed $INSIDE_IMAGE_USED
+            verifyStablePath $INSIDE_STABLE_PATH

--- a/test/black-box/sandbox/run.sh
+++ b/test/black-box/sandbox/run.sh
@@ -14,3 +14,34 @@ run_bob dev --sandbox -E root
 # Check that we can keep our UID or even be root inside sandbox
 run_bob dev --sandbox -c as-self -DEXPECT_UID=$UID root
 run_bob dev --sandbox -c as-root -DEXPECT_UID=0 root
+
+# Test properties in- and outside of sandbox image with respect to the various
+# modes...
+
+# The plain "--sandbox" mode executes packages without sandbox image unprotected.
+# With an image, the step is executed in a container with stable paths.
+cleanup
+run_bob dev isolation -D CANARY="$PWD/run.sh" --sandbox \
+	-D OUTSIDE_ISOLATED=0 -D OUTSIDE_STABLE_PATH=0 \
+	-D INSIDE_ISOLATED=1  -D INSIDE_STABLE_PATH=1 -D INSIDE_IMAGE_USED=1
+
+# The slim sandbox mode does not use the sandbox image. It will always use the
+# workspace paths but will execute still in an isolated environment.
+cleanup
+run_bob dev isolation -D CANARY="$PWD/run.sh" --slim-sandbox \
+	-D OUTSIDE_ISOLATED=1 -D OUTSIDE_STABLE_PATH=0 \
+	-D INSIDE_ISOLATED=1  -D INSIDE_STABLE_PATH=0 -D INSIDE_IMAGE_USED=0
+
+# The dev sandbox mode is like the slim mode, but will use the sandbox image if
+# available...
+cleanup
+run_bob dev isolation -D CANARY="$PWD/run.sh" --dev-sandbox \
+	-D OUTSIDE_ISOLATED=1 -D OUTSIDE_STABLE_PATH=0 \
+	-D INSIDE_ISOLATED=1  -D INSIDE_STABLE_PATH=0 -D INSIDE_IMAGE_USED=1
+
+# The strict sandbox mode always executes the steps in isolation with stable
+# paths. If a sandbox image is available, it is used.
+cleanup
+run_bob dev isolation -D CANARY="$PWD/run.sh" --strict-sandbox \
+	-D OUTSIDE_ISOLATED=1 -D OUTSIDE_STABLE_PATH=1 \
+	-D INSIDE_ISOLATED=1  -D INSIDE_STABLE_PATH=1 -D INSIDE_IMAGE_USED=1

--- a/test/unit/test_jenkins_set_options.py
+++ b/test/unit/test_jenkins_set_options.py
@@ -66,7 +66,7 @@ class TestJenkinsSetOptions(JenkinsTests, TestCase):
         self.assertTrue(c.keep)
         self.assertTrue(c.download)
         self.assertTrue(c.upload)
-        self.assertFalse(c.sandbox)
+        self.assertEqual(c.sandbox.mode, "no")
         self.assertFalse(c.clean)
 
     def testReset(self):
@@ -84,5 +84,5 @@ class TestJenkinsSetOptions(JenkinsTests, TestCase):
         self.assertFalse(c.keep)
         self.assertFalse(c.download)
         self.assertFalse(c.upload)
-        self.assertTrue(c.sandbox)
+        self.assertEqual(c.sandbox.mode, "yes")
         self.assertTrue(c.clean)

--- a/test/unit/test_jenkins_set_options.py
+++ b/test/unit/test_jenkins_set_options.py
@@ -86,3 +86,15 @@ class TestJenkinsSetOptions(JenkinsTests, TestCase):
         self.assertFalse(c.upload)
         self.assertEqual(c.sandbox.mode, "yes")
         self.assertTrue(c.clean)
+
+    def testSandboxModes(self):
+        self.executeBobJenkinsCmd("set-options test --no-sandbox")
+        self.assertEqual(BobState().getJenkinsConfig("test").sandbox.mode, "no")
+        self.executeBobJenkinsCmd("set-options test --sandbox")
+        self.assertEqual(BobState().getJenkinsConfig("test").sandbox.mode, "yes")
+        self.executeBobJenkinsCmd("set-options test --slim-sandbox")
+        self.assertEqual(BobState().getJenkinsConfig("test").sandbox.mode, "slim")
+        self.executeBobJenkinsCmd("set-options test --dev-sandbox")
+        self.assertEqual(BobState().getJenkinsConfig("test").sandbox.mode, "dev")
+        self.executeBobJenkinsCmd("set-options test --strict-sandbox")
+        self.assertEqual(BobState().getJenkinsConfig("test").sandbox.mode, "strict")


### PR DESCRIPTION
The `--sandbox` mode is nice but sometimes cumbersome to use. It will use stable paths (`/bob/...`) which is good for reproducibility but bad for debugging. OTOH, no isolation will be applied without a sandbox image. This PR adds a couple of other sandbox modes to make the usage more flexible:

* `--slim-sandbox`: Applies isolation (e.g. make dependencies read-only) but do not use a sandbox image, even if available. Do not virtualize paths.
* `--dev-sandbox`: Always apply isolation but use a sandbox image if available. Like the slim sandbox, do not virtualize paths.
* `--strict-sandbox`: Always apply isolation, *always* use stable paths and use the sandbox image if available.