### PR TITLE
layers: fix move to attic

### DIFF
--- a/pym/bob/cmds/layers.py
+++ b/pym/bob/cmds/layers.py
@@ -36,7 +36,7 @@ def doLayersUpdate(argv):
     parser.add_argument('-D', default=[], action='append', dest="defines",
         help="Override default environment variable")
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--attic', action='store_true', default=True,
+    group.add_argument('--attic', action='store_true', default=None,
         help="Move scm to attic if inline switch is not possible (default).")
     group.add_argument('--no-attic', action='store_false', default=None, dest='attic',
         help="Do not move to attic, instead fail the build.")

--- a/pym/bob/layers.py
+++ b/pym/bob/layers.py
@@ -208,7 +208,7 @@ class Layer:
 class Layers:
     def __init__(self, defines, attic):
         self.__layers = {}
-        self.__attic = attic
+        self.__attic = attic if attic is not None else True
         self.__defines = defines
         self.__layerConfigFiles = []
 


### PR DESCRIPTION
When the layers where updated from bob build/dev move to attic was disabled by default.
As the unittest only tests the attic move from `bob layers update` this has been overlooked as attic is True in this case while it's None for build/dev. Adapt the default for the layers update command to match the default from build/dev.