### PR TITLE
input: add substituteMetaEnv policy

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -1567,6 +1567,10 @@ This predestines metaEnvironment variables to add the license type or version of
 
 The :ref:`manpage-query-meta` command can be used to retrieve metaEnvironment variables.
 
+All metaEnvironment variables are subject to :ref:`string substitution
+<configuration-principle-subst>`, unless the :ref:`policies-substituteMetaEnv`
+policy is configured for the old behaviour.
+
 multiPackage
 ~~~~~~~~~~~~
 

--- a/doc/manual/policies.rst
+++ b/doc/manual/policies.rst
@@ -272,6 +272,24 @@ New behavior
     The ``fileMode`` attribute is default initialized to ``0600``. All files
     will get the same mode, regardless of the URL schema.
 
+.. _policies-substituteMetaEnv:
+
+substituteMetaEnv
+~~~~~~~~~~~~~~~~~
+
+Introduced in: 0.25
+
+Bob versions 0.24 and before did not apply string substitution to
+:ref:`configuration-recipes-metaenv` variables. Starting with Bob 0.25, regular
+string substitution is performed. Because older recipes might contain
+characters that need quoting, the substitution is subject to this policy.
+
+Old behavior
+    No substitution is applied to :ref:`configuration-recipes-metaenv` variables.
+
+New behavior
+    Apply string substitution to ``metaEnvironment`` variables.
+
 .. _policies-obsolete:
 
 Obsolete policies

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -2510,8 +2510,11 @@ class Recipe(object):
                                for key, value in i.items() })
 
         # meta variables override existing variables
-        metaEnv = { key : env.substitute(value, "metaEnvironment::"+key)
-            for key, value in self.__metaEnv.items() }
+        if self.__recipeSet.getPolicy('substituteMetaEnv'):
+            metaEnv = { key : env.substitute(value, "metaEnvironment::"+key)
+                for key, value in self.__metaEnv.items() }
+        else:
+            metaEnv = self.__metaEnv
         env.update(metaEnv)
 
         # set fixed built-in variables
@@ -2999,6 +3002,7 @@ class RecipeSet:
                 schema.Optional('gitCommitOnBranch') : bool,
                 schema.Optional('fixImportScmVariant') : bool,
                 schema.Optional('defaultFileMode') : bool,
+                schema.Optional('substituteMetaEnv') : bool,
             },
             error="Invalid policy specified! Are you using an appropriate version of Bob?"
         ),
@@ -3043,6 +3047,11 @@ class RecipeSet:
             InfoOnce("defaultFileMode policy not set. File mode of URL SCMs not set for locally copied files.",
                 help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#defaultfilemode for more information.")
         ),
+        "substituteMetaEnv": (
+            "0.25rc1",
+            InfoOnce("substituteMetaEnv policy is not set. MetaEnv will not be substituted.",
+                help="See http://bob-build-tool.readthedocs.io/en/latest/manual/policies.html#substitutemetaenv for more information.")
+        )
     }
 
     _ignoreCmdConfig = False

--- a/test/unit/test_input_recipe.py
+++ b/test/unit/test_input_recipe.py
@@ -200,7 +200,7 @@ class RecipeCommon:
         recipeSet = MagicMock()
         recipeSet.loadBinary = MagicMock()
         recipeSet.scriptLanguage = self.SCRIPT_LANGUAGE
-        recipeSet.getPolicy = lambda x: None
+        recipeSet.getPolicy = lambda x: True if x == "substituteMetaEnv" else None
 
         cc = { n : Recipe(recipeSet, self.applyRecipeDefaults(r), "", n+".yaml",
                           cwd, n, n, {}, False)


### PR DESCRIPTION
Using bob 0.25 on older recipes with unfortunate metaEnvironment strings raises a parse error. Add a policy to issue a warning only.