### PR TITLE
workflow: fix java selection on Windows

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -100,8 +100,7 @@ jobs:
               run: |
                 git config --global init.defaultBranch master # keep the old name
                 git config --global protocol.file.allow always # roll back CVE-2022-39253
-                $env:PATH = "$env:JAVA_HOME_11_X64\bin;$env:PATH;C:\msys64\usr\bin"
-                $env:JAVA_HOME = "$env:JAVA_HOME_11_X64"
+                $env:PATH = "$env:PATH;C:\msys64\usr\bin"
                 bash ./test/run-tests.sh -c xml
 
             - name: Upload coverage to Codecov


### PR DESCRIPTION
The setup-java action should be sufficient.