### PR TITLE
doc: Fix incorrect option "disassociate" in "checkoutSCM" git section

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -954,7 +954,7 @@ git    | ``url``: URL of remote repository
        |           local reference repo didn't exitst.
        |   Note: ``references`` are not used for submodules.
        | ``retries`` (\*): Number of retries before the checkout is set to failed.
-       | ``disassociate``: (Boolean, default false). Diasassociate the reference.
+       | ``dissociate``: (Boolean, default false). Dissociate the reference (see man git-clone).
 import | ``url``: Directory path relative to project root.
        | ``prune`` (\*): Delete destination directory before importing files.
 svn    | ``url``: URL of SVN module


### PR DESCRIPTION
Bob return failure when use `disassociate` in `checkoutSCM` section 
```
Parse error: Error while validating recipes/bob.yaml: Key 'checkoutSCM' error:
Wrong key 'disassociate' in {'scm': 'git', 'url': 'git@github.com:BobBuildTool/bob.git', 'branch': 'master', 'singleBranch': True, 'shallow': 1, 'disassociate': True}
```

Browse through the source code and `dissociate` is defined and used instead. 

Also fix typo and add man page section that explains the option