### PR TITLE
input: add support for package aliases

### DIFF
--- a/pym/bob/builder.py
+++ b/pym/bob/builder.py
@@ -328,7 +328,7 @@ cd {ROOT}
         if step.isCheckoutStep():
             base = step.getPackage().getRecipe().getName()
         else:
-            base = step.getPackage().getName()
+            base = step.getPackage().getRecipe().getPackageName()
         return os.path.join("work", base.replace('::', os.sep), step.getLabel())
 
     @staticmethod
@@ -351,7 +351,7 @@ cd {ROOT}
         if step.isCheckoutStep():
             base = step.getPackage().getRecipe().getName()
         else:
-            base = step.getPackage().getName()
+            base = step.getPackage().getRecipe().getPackageName()
         return os.path.join("dev", step.getLabel(), base.replace('::', os.sep))
 
     @staticmethod

--- a/pym/bob/cmds/jenkins/jenkins.py
+++ b/pym/bob/cmds/jenkins/jenkins.py
@@ -710,7 +710,7 @@ def _genJenkinsJobs(step, jobs, nameCalculator, upload, download, seenPackages, 
     return jj
 
 def jenkinsNameFormatter(step, props):
-    return step.getPackage().getName().replace('::', "/") + "/" + step.getLabel()
+    return step.getPackage().getRecipe().getPackageName().replace('::', "/") + "/" + step.getLabel()
 
 def jenkinsNamePersister(jenkins, wrapFmt, uuid):
 


### PR DESCRIPTION
Virtual packages transparently create an alias for a recipe. They are configured by yaml files in the newly defined `virtual` directory. For example, the file `virtual/libs/libegl.yaml`

```
multiPackage:
    "":  ${CONFIG_SELECT_LIBEGL:-libs::mesa3d}
    dev: ${CONFIG_SELECT_LIBEGL:-libs::mesa3d}-dev
    tgt: ${CONFIG_SELECT_LIBEGL:-libs::mesa3d}-tgt
```

would create packages `libs::libegl`, `libs::libegl-dev` and `libs::libegl-tgt` whose underlying recipe is selected by `CONFIG_SELECT_LIBEGL`.

If there is only one package, the yaml file can be a simple string containing just the target name.