### PR TITLE
test: filter HEAD from remote branch list

### DIFF
--- a/test/unit/test_input_gitscm.py
+++ b/test/unit/test_input_gitscm.py
@@ -460,7 +460,7 @@ class TestShallow(TestCase):
 
         branches = subprocess.check_output(["git", "branch", "-r"],
             cwd=workspace, universal_newlines=True).strip().split("\n")
-        branches = set(b.strip() for b in branches)
+        branches = set(b.strip() for b in branches if "HEAD" not in b)
 
         return (len(log), branches)
 


### PR DESCRIPTION
Looks like the default remote branch is sometimes displayed by git. Remove it to not be confused when comparing with expected branch set.