### PR TITLE
url: fix canary name of extracted archives

### DIFF
--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -170,7 +170,8 @@ class Extractor():
 
     async def _extract(self, cmds, invoker, stdout=None):
         destination = self.getCompressedFilePath(invoker)
-        canary = destination+".extracted"
+        (destDir, destFile) = os.path.split(destination)
+        canary = os.path.join(destDir, "."+destFile+".extracted")
         if isYounger(destination, canary):
             for cmd in cmds:
                 if shutil.which(cmd[0]) is None: continue

--- a/test/black-box/extractors/run.sh
+++ b/test/black-box/extractors/run.sh
@@ -16,10 +16,10 @@ fi
 run_bob dev -DINPUT_FILES="${INPUT}" -DIS_POSIX="$IS_POSIX" extract_test
 
 check_files() {
-  expect_not_exist dev/src/extract_test/1/workspace/$1/test.${2:-$1}.extracted
-  expect_not_exist dev/src/extract_test/1/workspace/$1/test.${2:-$1}
-  expect_exist dev/src/extract_test/1/download/$1/test.${2:-$1}.extracted
-  expect_exist dev/src/extract_test/1/download/$1/test.${2:-$1}
+  expect_not_exist "dev/src/extract_test/1/workspace/$1/.test.${2:-$1}.extracted"
+  expect_not_exist "dev/src/extract_test/1/workspace/$1/test.${2:-$1}"
+  expect_exist "dev/src/extract_test/1/download/$1/.test.${2:-$1}.extracted"
+  expect_exist "dev/src/extract_test/1/download/$1/test.${2:-$1}"
 }
 
 check_files "tar" "tgz"


### PR DESCRIPTION
With the introduction of separate download directories in 2dffbccc, the extraction canary had changed its name. This change affects the source hash in case the urlScmSeparateDownload is kept on the old behaviour, though. To keep backwards compatibility, name the canary exactly like before.