### PR TITLE
url: fix crash when switching between git and url SCM

### DIFF
--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -636,11 +636,11 @@ class UrlScm(Scm):
             invoker.fail("Upload not supported for URL scheme: " + url.scheme)
 
     def canSwitch(self, oldScm):
-        if self.__separateDownload != oldScm.__separateDownload:
-            return False
-
         diff = self._diffSpec(oldScm)
         if "scm" in diff:
+            return False
+
+        if self.__separateDownload != oldScm.__separateDownload:
             return False
 
         # Filter irrelevant properties


### PR DESCRIPTION
Before accessing any members of the old SCM, we need to make sure that it has the same type. Thus, the test for the "scm" property in the diff has to come first.