### PR TITLE
cmds/archive: fix lost exception

### DIFF
--- a/pym/bob/cmds/archive.py
+++ b/pym/bob/cmds/archive.py
@@ -77,8 +77,8 @@ class ArchiveScanner:
         return False
 
     def scan(self, verbose):
+        found = False
         try:
-            found = False
             self.__db.execute("BEGIN")
             for l1 in os.listdir("."):
                 if not self.__dirSchema.fullmatch(l1): continue
@@ -98,7 +98,7 @@ class ArchiveScanner:
                 print("Your archive seems to be empty. "
                       "Are you running 'bob archive' from within the correct directory?",
                       file=sys.stderr)
-            return found
+        return found
 
     def __scan(self, fileName, verbose):
         try:


### PR DESCRIPTION
A return in the finally block silently swallows the exception instead of reraising it. This caused archive scanning to be silently stopped on a exception and results in many unhandled archives.