### PR TITLE
test: do not call end_headers() after send_error()

### DIFF
--- a/test/unit/mocks/http_server.py
+++ b/test/unit/mocks/http_server.py
@@ -14,11 +14,9 @@ def createHttpHandler(repoPath, args):
                 fs = os.fstat(f.fileno())
             except FileNotFoundError:
                 self.send_error(404, "not found")
-                self.end_headers()
                 return None
             except OSError:
                 self.send_error(500, "internal error")
-                self.end_headers()
                 return None
 
             if "If-Modified-Since" in self.headers:
@@ -46,7 +44,6 @@ def createHttpHandler(repoPath, args):
                 return
             if args.get('retries') > 0:
                 self.send_error(500, "internal error (retries={})".format(args['retries']))
-                self.end_headers()
                 args['retries'] = args.get('retries') - 1
                 return
 
@@ -63,7 +60,6 @@ def createHttpHandler(repoPath, args):
                 return
             if args.get('retries') > 0:
                 self.send_error(500, "internal error")
-                self.end_headers()
                 args['retries'] = args.get('retries') - 1
                 return
 

--- a/test/unit/test_archive.py
+++ b/test/unit/test_archive.py
@@ -479,9 +479,8 @@ def createHttpHandler(repoPath, username=None, password=None):
                 challenge = 'Basic ' + base64.b64encode(
                     (username+":"+password).encode("utf-8")).decode("ascii")
                 if self.headers.get('Authorization') != challenge:
-                    self.send_error(401, "Unauthorized")
                     self.send_header("WWW-Authenticate", 'Basic realm="default"')
-                    self.end_headers()
+                    self.send_error(401, "Unauthorized")
                     return None
 
             path = repoPath + self.path


### PR DESCRIPTION
Internally, send_error() already calls end_headers(). Doing it twice will race with the client and provokes a BrokenPipeError if the client closed its connection faster than we could send the blank line.