### PR TITLE
webdav: do not consider 404 an error for delete

### DIFF
--- a/pym/bob/webdav.py
+++ b/pym/bob/webdav.py
@@ -196,7 +196,7 @@ class WebDav:
         connection.request("DELETE", filepath, headers=headers)
         response = connection.getresponse()
         response.read()
-        if response.status not in [200, 204]:
+        if response.status not in [200, 204, 404]:
             raise HttpDownloadError("DELETE {} {}".format(response.status, response.reason))
 
     def stat(self, file):

--- a/test/unit/test_webdav.py
+++ b/test/unit/test_webdav.py
@@ -127,8 +127,23 @@ class TestWebdav(TestCase):
             webdav.delete(TEST_FILE)
             # file should be deleted
             self.assertFalse(os.path.exists(path))
+            # deleting again should not cause any problems
+            webdav.delete(TEST_FILE)
+            self.assertFalse(os.path.exists(path))
+        with HttpServerMock(self.dir, retries=1) as srv:
+            path = os.path.join(self.dir, TEST_FILE)
+            with open(path, 'w') as f:
+                f.write(TEST_OUTPUT)
+            self.assertTrue(os.path.exists(path))
+            webdav = GetWebdav(srv.port)
+            # first attempt fails, so HttpDownloadError is rasied
             with self.assertRaises(HttpDownloadError) as cm:
                 webdav.delete(TEST_FILE)
+            self.assertTrue(os.path.exists(path))
+            # second attempt will succeed
+            webdav.delete(TEST_FILE)
+            # file should be deleted
+            self.assertFalse(os.path.exists(path))
 
     def testMkdir(self):
         with HttpServerMock(self.dir) as srv:


### PR DESCRIPTION
deleting a file that is not there (anymore) should not throw an exception. this caused some issues in our company's interal CỊ where cache issues lead to delete attempts on files that were already gone