### PR TITLE
Conditional share attribute

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -2018,7 +2018,7 @@ either case the command must be present in ``$PATH``/``%PATH%``.
 shared
 ~~~~~~
 
-Type: Boolean
+Type: Boolean | String | IfExpression (:ref:`configuration-principle-booleans`)
 
 Marking a recipe as shared implies that the result may be shared between
 different projects or workspaces. Only completely deterministic packages may be

--- a/pym/bob/cmds/show.py
+++ b/pym/bob/cmds/show.py
@@ -35,7 +35,7 @@ def dumpPackage(package):
             "deterministic" : package.getPackageStep().isDeterministic(),
         },
         "scriptLanguage" : recipe.scriptLanguage.index.value,
-        "shared" : recipe.isShared(),
+        "shared" : package.isShared(),
         "metaEnvironment" : package.getMetaEnv(),
         "relocatable" : package.isRelocatable(),
         "jobServer" : recipe.jobServer(),

--- a/test/unit/test_input_recipe.py
+++ b/test/unit/test_input_recipe.py
@@ -742,3 +742,57 @@ class TestEnvironment(RecipeCommon, TestCase):
             "B" : "<lib>b",
             "C" : "<b>",
         })
+
+
+class TestShared(RecipeCommon, TestCase):
+
+    def testBool(self):
+        recipe = {
+            "shared" : True,
+        }
+        p = self.parseAndPrepare(recipe).getPackageStep()
+        self.assertTrue(p.isShared())
+
+        recipe = {
+            "shared" : False,
+        }
+        p = self.parseAndPrepare(recipe).getPackageStep()
+        self.assertFalse(p.isShared())
+
+        recipe = {
+        }
+        p = self.parseAndPrepare(recipe).getPackageStep()
+        self.assertFalse(p.isShared())
+
+    def testString(self):
+        recipe = {
+            "shared" : "True",
+        }
+        p = self.parseAndPrepare(recipe).getPackageStep()
+        self.assertTrue(p.isShared())
+
+        recipe = {
+            "shared" : "0",
+        }
+        p = self.parseAndPrepare(recipe).getPackageStep()
+        self.assertFalse(p.isShared())
+
+    def testStringSubst(self):
+        recipe = {
+            "shared" : "$(eq,$ENABLE,yes)",
+        }
+
+        p = self.parseAndPrepare(recipe, env={"ENABLE" : "yes"}).getPackageStep()
+        self.assertTrue(p.isShared())
+        p = self.parseAndPrepare(recipe, env={"ENABLE" : "no"}).getPackageStep()
+        self.assertFalse(p.isShared())
+
+    def testIfExpr(self):
+        recipe = {
+            "shared" : IfExpression('"$ENABLE" == "yes"'),
+        }
+
+        p = self.parseAndPrepare(recipe, env={"ENABLE" : "yes"}).getPackageStep()
+        self.assertTrue(p.isShared())
+        p = self.parseAndPrepare(recipe, env={"ENABLE" : "no"}).getPackageStep()
+        self.assertFalse(p.isShared())


### PR DESCRIPTION
Allow a boolean string or an IfCondition as value of the "shared"
attribute. Sometimes a package could be used for host and target builds.
Only in case of the former it makes sense to share the artifact.