### PR TITLE
Urlscm: add support for custom headers

### DIFF
--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -985,7 +985,7 @@ url    | ``url``: File that should be downloaded
        | ``stripComponents`` (\*): Number of leading components stripped from file name
        |                           (optional, tar files only)
        | ``retries`` (\*): Number of retries before the checkout is set to failed.
-       | ``headers``: A list of dictionaries with key value fields used as extra headers for requests. (optional)
+       | ``headers``: A dictionary of key value pairs used as extra headers for requests. (optional)
 ====== =======================================================================================
 
 The following synthetic attributes exist. They are generated internally

--- a/doc/manual/configuration.rst
+++ b/doc/manual/configuration.rst
@@ -985,6 +985,7 @@ url    | ``url``: File that should be downloaded
        | ``stripComponents`` (\*): Number of leading components stripped from file name
        |                           (optional, tar files only)
        | ``retries`` (\*): Number of retries before the checkout is set to failed.
+       | ``headers``: A list of dictionaries with key value fields used as extra headers for requests. (optional)
 ====== =======================================================================================
 
 The following synthetic attributes exist. They are generated internally
@@ -1186,6 +1187,11 @@ url
    command syntax. Examples: ``0764``, ``"u=rwx,g=rw,o=r"``. The ``fileMode``
    defaults to ``0600``/``"u=rw"`` unless the :ref:`policies-defaultFileMode`
    policy is configured for the old behaviour.
+
+   Some requests might need additional header fields set, e.g. a token required for
+   authentication. These additional header fields can be provided using the
+   ``headers`` attribute, which expects a list of key value pairs, with string
+   substitution applied to the value.
 
 .. _configuration-recipes-checkoutUpdateIf:
 

--- a/pym/bob/input.py
+++ b/pym/bob/input.py
@@ -372,10 +372,16 @@ class BuiltinSetting(PluginSetting):
             return False
 
 def Scm(spec, env, overrides, recipeSet):
+    def _substitute(k, v):
+        if isinstance(v, str) and k not in ('__source', 'recipe'):
+            return env.substitute(v, "checkoutSCM::"+k)
+        elif isinstance(v, dict):
+            return { k1 : _substitute(k+"::"+k1, v1) for (k1, v1) in v.items() }
+        else:
+            return v
+
     # resolve with environment
-    spec = { k : ( env.substitute(v, "checkoutSCM::"+k)
-                   if isinstance(v, str) and k not in ('__source', 'recipe')
-                   else v )
+    spec = { k : _substitute(k,v)
         for (k, v) in spec.items() }
 
     # apply overrides before creating scm instances. It's possible to switch the Scm type with an override..

--- a/pym/bob/scm/url.py
+++ b/pym/bob/scm/url.py
@@ -309,6 +309,7 @@ class UrlScm(Scm):
         schema.Optional('digestSHA1') : str,
         schema.Optional('digestSHA256') : str,
         schema.Optional('digestSHA512') : str,
+        schema.Optional('headers') : schema.Schema({str : str}),
     }
 
     DEFAULTS = {
@@ -406,6 +407,7 @@ class UrlScm(Scm):
         self.__fallbackMirrorsUpload = spec.get("__fallbackMirrorsUpload")
         self.__fileMode = spec.get("fileMode", 0o600 if defaultFileMode else None)
         self.__separateDownload = spec.get("__separateDownload", separateDownload)
+        self.__headers = spec.get("headers", {})
 
     def getProperties(self, isJenkins, pretty=False):
         ret = super().getProperties(isJenkins, pretty)
@@ -424,6 +426,7 @@ class UrlScm(Scm):
             'preMirrors' : self.__getPreMirrorsUrls(),
             'fallbackMirrors' : self.__getFallbackMirrorsUrls(),
             'fileMode' : dumpMode(self.__fileMode) if pretty else self.__fileMode,
+            'headers' : self.__headers
         })
         if not pretty:
             ret.update({
@@ -482,6 +485,7 @@ class UrlScm(Scm):
     def _download(self, url, destination, mode):
         headers = {}
         headers["User-Agent"] = "BobBuildTool/{}".format(BOB_VERSION)
+        headers.update(self.__headers)
         context = None if self.__sslVerify else sslNoVerifyContext()
         if os.path.isfile(destination) and (url.scheme in ["http", "https"]):
             # Try to avoid download if possible


### PR DESCRIPTION
Some servers need additional informations provided by custom headers.
Add a `headers` attribute where the user can set these custom headers.
