### PR TITLE
RFC archive: Do not bail on DNS failure

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -465,7 +465,7 @@ class BaseArchive(TarHelper):
                 break
 
         if self.__ignoreDownloadErrors and err.errno in SOFT_DOWNLOAD_ERRORS:
-            return (softerror_return, self._namedErrorString(os.strerror(err.errno)), WARNING)
+            return (softerror_return, self._namedErrorString(str(err)), WARNING)
         raise BuildError(self._namedErrorString(message + ": " + str(err)))
 
     def _downloadPackage(self, buildId, suffix, audit, content, caches, workspace):


### PR DESCRIPTION
Fixes the following error:

Build error: ci.bobbuildtool.dev: Cannot download file: \
  [Errno -3] Temporary failure in name resolution

Not sure about the error string handling, the correct one would be `str(err)`, but I don't see it displayed anyway.