### PR TITLE
invoker: don't show output of captured commands by default

### DIFF
--- a/pym/bob/invoker.py
+++ b/pym/bob/invoker.py
@@ -291,7 +291,11 @@ class Invoker:
             # If stdout should be captured we use a dedicated buffer. This
             # buffer is then returned to the caller at child exit.
             stdoutRedir = subprocess.PIPE
-            stdoutStreams = [io.BytesIO(), self.__stdoutStream]
+            stdoutStreams = [io.BytesIO()]
+            if self.__trace:
+                # Only show stdout to the user if the command is traced.
+                # Otherwise it is unclear where it came from.
+                stdoutStreams.append(self.__stdoutStream)
         elif stdout == False:
             stdoutRedir = subprocess.DEVNULL
             stdoutStreams = []
@@ -306,7 +310,11 @@ class Invoker:
             # If stderr should be captured we use a dedicated buffer. This
             # buffer is then returned to the caller at child exit.
             stderrRedir = subprocess.PIPE
-            stderrStreams = [io.BytesIO(), self.__stderrStream]
+            stderrStreams = [io.BytesIO()]
+            if self.__trace:
+                # Only show stderr to the user if the command is traced.
+                # Otherwise it is unclear where it came from.
+                stderrStreams.append(self.__stderrStream)
         elif stderr == False:
             stderrRedir = subprocess.DEVNULL
             stderrStreams = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.0", "Sphinx"]
+requires = ["setuptools >= 40.0", "setuptools-scm", "Sphinx"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -147,11 +147,6 @@ setup(
         'azure' : [ 'azure-storage-blob' ],
     },
 
-    # Installation time dependencies only needed by setup.py
-    setup_requires = [
-        'setuptools_scm',   # automatically get package version
-    ],
-
     # Provide executables
     entry_points = {
         'console_scripts' : [


### PR DESCRIPTION
Capturing the output (stdout and/or stderr) of a command and the visibility of the output streams to the user used to be independent options. This is confusing, though. If the output is captured, it means that it is coming from some redirected, Bob-internal command. The user is unaware what command that is and will just observe random output.

To make it more understandable, show the redirected output only if the command is traced.

Fixes #699.