### PR TITLE
scm: make ScmOverride hashable with nested values

### DIFF
--- a/pym/bob/scm/scm.py
+++ b/pym/bob/scm/scm.py
@@ -13,6 +13,19 @@ import re
 
 SYNTHETIC_SCM_PROPS = frozenset(('__source', 'recipe', 'overridden'))
 
+def _freezeValue(value):
+    """Recursively turn a (possibly nested) value into a hashable one.
+
+    scmOverrides 'match' and 'set' allow arbitrary values (e.g. the 'headers'
+    dict of an url SCM). Such nested dicts/lists are unhashable, so convert
+    them into frozensets/tuples to make ScmOverride hashable.
+    """
+    if isinstance(value, dict):
+        return frozenset((k, _freezeValue(v)) for k, v in value.items())
+    if isinstance(value, list):
+        return tuple(_freezeValue(v) for v in value)
+    return value
+
 class ScmOverride:
     def __init__(self, override):
         self.__match = override.get("match", {})
@@ -54,8 +67,8 @@ class ScmOverride:
         return True
 
     def __hash__(self):
-        return hash((frozenset(self.__match.items()), frozenset(self.__del),
-            frozenset(self.__set.items()), frozenset(self.__replace.items())))
+        return hash((_freezeValue(self.__match), frozenset(self.__del),
+            _freezeValue(self.__set), frozenset(self.__replace.items())))
 
     def __eq__(self, other):
         return ((self.__match, self.__del, self.__set, self.__replace) ==

--- a/test/unit/test_input_scmoverride.py
+++ b/test/unit/test_input_scmoverride.py
@@ -207,3 +207,36 @@ class TestScmOverride(TestCase):
 
         o = ScmOverride(spec)
         self.assertEqual(spec, yaml.load(str(o), Loader=yaml.Loader))
+
+    def testHashableNestedValue(self):
+        """A scmOverride with a nested dict value (e.g. url SCM headers) must
+        still be hashable. The builder collects active overrides in a set()."""
+        o = ScmOverride({
+            'match' : { 'url' : "https://gitea.example.com/*" },
+            'set' : { 'headers' : { 'Authorization' : "token 1234" } },
+        })
+        # Must not raise "unhashable type: 'dict'".
+        self.assertIn(o, { o })
+
+        # Equal overrides hash equally, unequal ones stay distinct.
+        same = ScmOverride({
+            'match' : { 'url' : "https://gitea.example.com/*" },
+            'set' : { 'headers' : { 'Authorization' : "token 1234" } },
+        })
+        other = ScmOverride({
+            'match' : { 'url' : "https://gitea.example.com/*" },
+            'set' : { 'headers' : { 'Authorization' : "token 4321" } },
+        })
+        self.assertEqual(hash(o), hash(same))
+        self.assertEqual(len({ o, same, other }), 2)
+
+    def testMangleNestedValue(self):
+        """A nested dict value is injected verbatim into the matched SCM."""
+        o = ScmOverride({
+            'match' : { 'scm' : "url" },
+            'set' : { 'headers' : { 'Authorization' : "token 1234" } },
+        })
+        scm = { 'scm' : "url", 'url' : "https://gitea.example.com/x.tar" }
+        match, mangled = o.mangle(scm, Env())
+        self.assertTrue(match)
+        self.assertEqual(mangled['headers'], { 'Authorization' : "token 1234" })


### PR DESCRIPTION
## Problem

`scmOverrides` allows arbitrary values in `match` and `set` (schema `{str: object}`).
A natural use case is injecting authentication headers into a `url` SCM so that
downloads from a private server work — matched by host and kept out of the
version-controlled recipe:

```yaml
scmOverrides:
   - match:
       url: "https://gitea.example.com/*"
     set:
       headers:
         Authorization: "token <personal access token>"
```

This crashes as soon as the override actually matches:

```
  File ".../bob/scm/scm.py", line 58, in __hash__
    frozenset(self.__set.items()), frozenset(self.__replace.items())))
TypeError: unhashable type: 'dict'
```

`ScmOverride.__hash__` builds a `frozenset` directly from the raw match/set
items. A nested dict/list value (like headers) is unhashable, and since
matched overrides are collected into a `set()` in the builder
(`builder.getActiveOverrides()`), any build that hits such an override fails.

## Fix

Recursively freeze nested dict/list values into frozenset/tuple before
`hashing. __eq__` already compares the raw structures correctly and is left
unchanged.

## Tests

Added two regression tests to `test/unit/test_input_scmoverride.py`:
- a set with a nested headers dict is hashable and behaves correctly in a
`set()` (equal overrides collapse, unequal ones stay distinct);
- the nested value is injected verbatim into the matched SCM.

## Note

This came out of a discussion about a proposed urlCredentials config option.
With this fix, authenticated url SCMs can be handled entirely through the
existing headers attribute + scmOverrides (kept in a git-ignored
user.yaml), so no dedicated credentials setting is needed.