### PR TITLE
archive: do not leak URL credentials in user visible messages

### DIFF
--- a/pym/bob/archive.py
+++ b/pym/bob/archive.py
@@ -24,7 +24,8 @@ from .errors import BuildError, BobError
 from .tty import stepAction, stepMessage, \
     SKIPPED, EXECUTED, WARNING, INFO, TRACE, ERROR, IMPORTANT
 from .utils import asHexStr, removePath, isWindows, getBashPath, tarfileOpen, binStat
-from .webdav import WebDav, WebdavError, WebdavNotFoundError, WebdavAlreadyExistsError
+from .webdav import WebDav, WebdavError, WebdavNotFoundError, WebdavAlreadyExistsError, \
+    getNetLoc
 from tempfile import mkstemp, NamedTemporaryFile, TemporaryFile, gettempdir
 import asyncio
 import concurrent.futures
@@ -874,7 +875,7 @@ class HttpArchive(BaseArchive):
             return name
 
         url = self.__url
-        return urllib.parse.urlunparse((url.scheme, url.netloc, url.path, '', '', ''))
+        return urllib.parse.urlunparse((url.scheme, getNetLoc(url), url.path, '', '', ''))
 
     def __retry(self, request):
         retries = self._retries
@@ -899,7 +900,7 @@ class HttpArchive(BaseArchive):
 
     def _remoteName(self, buildId, suffix):
         url = self.__url
-        return urllib.parse.urlunparse((url.scheme, url.netloc, self._makePath(buildId, suffix), '', '', ''))
+        return urllib.parse.urlunparse((url.scheme, getNetLoc(url), self._makePath(buildId, suffix), '', '', ''))
 
     def _exists(self, path):
         return self.__retry(lambda: self._webdav.exists(path))
@@ -963,7 +964,7 @@ class HttpArchive(BaseArchive):
                 pass
 
     def getArchiveUri(self):
-        return self.__url.netloc + self.__url.path
+        return getNetLoc(self.__url) + self.__url.path
 
 
 class HttpDownloader:

--- a/pym/bob/webdav.py
+++ b/pym/bob/webdav.py
@@ -28,7 +28,9 @@ def getNetLoc(url):
     """
     netloc = url.netloc
     if url.username is not None:
-        netloc = netloc.split('@')[1]
+        # urlparse() delimits the user info at the *last* '@'. Cut at the same
+        # one, otherwise a password with an unencoded '@' yields a bogus host.
+        netloc = netloc.rsplit('@', 1)[1]
 
     return netloc
 

--- a/pym/bob/webdav.py
+++ b/pym/bob/webdav.py
@@ -18,6 +18,21 @@ class WebdavNotFoundError(WebdavError):
 class WebdavAlreadyExistsError(WebdavError):
     pass
 
+
+def getNetLoc(url):
+    """Get the network location of a parsed URL without the credentials.
+
+    The user name and password of the HTTP basic authentication are part of
+    the URL. They are sent in the Authorization header instead and must be
+    kept out of the request URL and of anything that is shown to the user.
+    """
+    netloc = url.netloc
+    if url.username is not None:
+        netloc = netloc.split('@')[1]
+
+    return netloc
+
+
 class WebDav:
 
     class PartialDownloader:
@@ -55,12 +70,7 @@ class WebDav:
         return headers
 
     def _getURL(self, path):
-        # remove username and password from URI
-        netloc = self.__url.netloc
-        if self.__url.username is not None:
-            netloc = self.__url.netloc.split('@')[1]
-
-        return urlunsplit((self.__url.scheme, netloc, path,
+        return urlunsplit((self.__url.scheme, getNetLoc(self.__url), path,
                            self.__url.query, self.__url.fragment))
 
     def exists(self, path):

--- a/test/unit/test_archive.py
+++ b/test/unit/test_archive.py
@@ -25,7 +25,7 @@ from mocks.http_server import HttpServerMock
 from bob.archive import DummyArchive, HttpArchive, getArchiver
 from bob.errors import BuildError
 from bob.utils import runInEventLoop, getProcessPoolExecutor
-from bob.webdav import WebdavError
+from bob.webdav import WebdavError, getNetLoc
 
 DOWNLOAD_ARITFACT = b'\x00'*20
 NOT_EXISTS_ARTIFACT = b'\x01'*20
@@ -691,6 +691,51 @@ class TestHttpBasicAuthArchive(BaseTester, TestCase):
 
         run(archive.downloadPackage(DummyStep(), b'\x00'*20, "unused", "unused", executor=self.executor))
         self.assertEqual(run(archive.downloadLocalLiveBuildId(DummyStep(), b'\x00'*20, executor=self.executor)), None)
+
+    def testNoCredentialsInMessages(self):
+        """The URL credentials must never show up in user visible strings.
+
+        Everything that is derived from the URL ends up in log messages and
+        therefore in build logs and CI consoles.
+        """
+        spec = { }
+        self._setArchiveSpec(spec)
+        archive = HttpArchive(spec)
+
+        for name, uri in [
+                ("getArchiveName", archive.getArchiveName()),
+                ("getArchiveUri", archive.getArchiveUri()),
+                ("_remoteName", archive._remoteName(DOWNLOAD_ARITFACT, ".tgz")),
+            ]:
+            with self.subTest(method=name):
+                self.assertNotIn(self.PASSWORD, uri)
+                self.assertNotIn(urllib.parse.quote(self.PASSWORD), uri)
+                self.assertNotIn("@", uri)
+                # ...but the host must still be there to be of any use
+                self.assertIn("{}:{}".format(self.ip, self.port), uri)
+
+
+class TestGetNetLoc(TestCase):
+    """Unit tests for the URL credential sanitizer."""
+
+    def testNoCredentials(self):
+        url = urllib.parse.urlparse("https://host.test:8443/path")
+        self.assertEqual(getNetLoc(url), "host.test:8443")
+
+    def testCredentialsRemoved(self):
+        url = urllib.parse.urlparse("https://user:pass@host.test:8443/path")
+        self.assertEqual(getNetLoc(url), "host.test:8443")
+
+    def testPasswordWithAtSign(self):
+        """urlparse() delimits at the *last* '@'. We must cut at the same one."""
+        url = urllib.parse.urlparse("https://user:p@ssw@rd@host.test/path")
+        self.assertEqual(url.hostname, "host.test")
+        self.assertEqual(getNetLoc(url), "host.test")
+
+    def testIPv6(self):
+        url = urllib.parse.urlparse("https://user:pass@[::1]:8443/path")
+        self.assertEqual(getNetLoc(url), "[::1]:8443")
+
 
 @skipIf(sys.platform.startswith("win"), "requires POSIX platform")
 class TestCustomArchive(BaseTester, TestCase):


### PR DESCRIPTION
## Problem

The HTTP basic authentication credentials of the `http` archive backend are
part of the URL, as documented. All three places that turn that URL back into
a string for display use the raw `netloc`, which still carries the
`user:password@` part:

| | leaks via | visible |
|---|---|---|
| `getArchiveName()` (`archive.py:877`) | `_namedErrorString()` (`archive.py:401`) | always, no flag needed |
| `_remoteName()` (`archive.py:902`) | `details` of the `DOWNLOAD`/`UPLOAD`/`MAP-SRC`/`CACHE-BID`/`CACHE-FPR`/`MAP-FPRNT` status lines | with `-v` |
| `getArchiveUri()` (`archive.py:966`) | `bob archive` (`cmds/archive.py:32`) | always |

The first one is the bad one. `_namedErrorString()` is used for *every* error
message, including the perfectly ordinary "artifact not found" that happens for
each package on a cache miss. So a plain `bob build` on a cold cache prints the
password once per package:

```
>> aarch64::linux/devel::sandbox/core::coreutils
   DOWNLOAD  work/core/coreutils/.../workspace .. https://user:s3cr3t@server.test/artifacts: artifact not found
```

These messages routinely end up in build logs, CI consoles and pasted-into-an-issue
snippets.

The optional `name` archive setting is not a workaround: `_remoteName()` and
`getArchiveUri()` never consult it.

Note this is a display-only issue. `WebDav._getURL()` already strips the
credentials before the URL goes on the wire; they are sent in the
`Authorization` header (`webdav.py:47-55`).

## Fix

Factor the stripping that `WebDav._getURL()` already does into a
`stripUserInfo()` helper and use it in the three places above as well.

It takes and returns a parsed URL and preserves the result type, so both the
`urlsplit()` result used in `webdav.py` and the `urlparse()` result used in
`archive.py` work.

### Drive-by: cut at the last `@`, not the first

The existing implementation used `netloc.split('@')[1]`. `urlparse()` delimits
the user info at the **last** `@`, so the two disagree when the password
contains an unencoded `@`:

```python
>>> urlparse('https://u:p@ss@host:8443/x').netloc
'u:p@ss@host:8443'
>>> _.split('@')[1]        # before: bogus host, and part of the password survives
'ss'
>>> _.rsplit('@', 1)[1]    # after
'host:8443'
```

Percent encoding is documented as required, so this was latent rather than a
live bug, but there is no reason to get it wrong.

## Tests

- `TestHttpBasicAuthArchive.testNoCredentialsInMessages` — asserts all three
  methods drop the password and the `@`, and still contain the host.
- `TestStripUserInfo` — no credentials (identity), removal, `@` in the
  password, IPv6 literal, `urlsplit()` type preservation.

Reverting `archive.py` alone makes the first test fail on all three subtests;
`test_archive` + `test_webdav` are green with the fix (71 tests).
